### PR TITLE
chore: upgrade rc-dialog to 8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@ant-design/icons": "^4.2.2",
     "@babel/runtime": "^7.11.2",
     "classnames": "^2.2.6",
-    "rc-dialog": "~8.2.2",
+    "rc-dialog": "~8.3.4",
     "rc-util": "^5.0.6"
   },
   "devDependencies": {

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import Dialog from 'rc-dialog';
-import { IDialogPropTypes } from 'rc-dialog/lib/IDialogPropTypes';
+import Dialog, { DialogProps as IDialogPropTypes } from 'rc-dialog';
 import RotateLeftOutlined from '@ant-design/icons/RotateLeftOutlined';
 import RotateRightOutlined from '@ant-design/icons/RotateRightOutlined';
 import ZoomInOutlined from '@ant-design/icons/ZoomInOutlined';


### PR DESCRIPTION
升级 rc-dialog 到 8.3.x，rc-image 需要发一个 3.1.0，到 antd 的 feature 分支升级起来。

https://github.com/react-component/image/commit/51569b0dd59b5bc39889e17341437f9449b373b0