### PR TITLE
fix: imgStyle and imgClass in Image Component

### DIFF
--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -14,8 +14,8 @@ export interface ImageProps
   extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onClick'> {
   // Original
   src?: string;
-  imgClass?: string;
-  imgStyle?: React.CSSProperties;
+  wrapperClassName?: string;
+  wrapperStyle?: React.CSSProperties;
   prefixCls?: string;
   previewPrefixCls?: string;
   placeholder?: React.ReactNode;
@@ -44,12 +44,12 @@ const ImageInternal: React.FC<ImageProps> = ({
   height,
   style,
   preview = true,
-  className: originalClassName,
+  className,
   onClick,
+  wrapperClassName,
+  wrapperStyle,
 
   // Img
-  imgClass,
-  imgStyle,
   crossOrigin,
   decoding,
   loading,
@@ -107,7 +107,7 @@ const ImageInternal: React.FC<ImageProps> = ({
     }
   }, [src]);
 
-  const className = cn(prefixCls, originalClassName, {
+  const wrappperClass = cn(prefixCls, wrapperClassName, {
     [`${prefixCls}-error`]: isError,
   });
 
@@ -126,12 +126,12 @@ const ImageInternal: React.FC<ImageProps> = ({
       {
         [`${prefixCls}-img-placeholder`]: placeholder === true,
       },
-      imgClass,
+      className,
     ),
     style: {
       height,
       width,
-      ...imgStyle,
+      ...style
     },
   };
 
@@ -139,11 +139,9 @@ const ImageInternal: React.FC<ImageProps> = ({
     <>
       <div
         {...otherProps}
-        className={className}
+        className={wrappperClass}
         onClick={preview && !isError ? onPreview : onClick}
-        style={{
-          ...style,
-        }}
+        style={wrapperStyle}
       >
         {isError && fallback ? (
           <img {...imgCommonProps} src={fallback} />

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -130,8 +130,7 @@ const ImageInternal: React.FC<ImageProps> = ({
     ),
     style: {
       height,
-      width,
-      ...style
+      ...style,
     },
   };
 
@@ -141,7 +140,11 @@ const ImageInternal: React.FC<ImageProps> = ({
         {...otherProps}
         className={wrappperClass}
         onClick={preview && !isError ? onPreview : onClick}
-        style={wrapperStyle}
+        style={{
+          width,
+          height,
+          ...wrapperStyle,
+        }}
       >
         {isError && fallback ? (
           <img {...imgCommonProps} src={fallback} />

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -14,7 +14,8 @@ export interface ImageProps
   extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onClick'> {
   // Original
   src?: string;
-
+  imgClass?: string;
+  imgStyle?: React.CSSProperties;
   prefixCls?: string;
   previewPrefixCls?: string;
   placeholder?: React.ReactNode;
@@ -47,6 +48,8 @@ const ImageInternal: React.FC<ImageProps> = ({
   onClick,
 
   // Img
+  imgClass,
+  imgStyle,
   crossOrigin,
   decoding,
   loading,
@@ -118,10 +121,18 @@ const ImageInternal: React.FC<ImageProps> = ({
     srcSet,
     useMap,
     alt,
-    className: cn(`${prefixCls}-img`, {
-      [`${prefixCls}-img-placeholder`]: placeholder === true,
-    }),
-    style: height !== undefined ? { height } : undefined,
+    className: cn(
+      `${prefixCls}-img`,
+      {
+        [`${prefixCls}-img-placeholder`]: placeholder === true,
+      },
+      imgClass,
+    ),
+    style: {
+      height,
+      width,
+      ...imgStyle,
+    },
   };
 
   return (
@@ -132,8 +143,6 @@ const ImageInternal: React.FC<ImageProps> = ({
         onClick={preview && !isError ? onPreview : onClick}
         style={{
           ...style,
-          width,
-          height,
         }}
       >
         {isError && fallback ? (

--- a/tests/__snapshots__/basic.test.tsx.snap
+++ b/tests/__snapshots__/basic.test.tsx.snap
@@ -8,18 +8,19 @@ exports[`Basic snapshot 1`] = `
   <div
     className="rc-image"
     onClick={[Function]}
-    style={
-      Object {
-        "height": undefined,
-        "width": 200,
-      }
-    }
+    style={Object {}}
   >
     <img
       className="rc-image-img"
       onError={[Function]}
       onLoad={[Function]}
       src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      style={
+        Object {
+          "height": undefined,
+          "width": 200,
+        }
+      }
     />
   </div>
   <Preview

--- a/tests/__snapshots__/basic.test.tsx.snap
+++ b/tests/__snapshots__/basic.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`Basic snapshot 1`] = `
   <div
     className="rc-image"
     onClick={[Function]}
-    style={Object {}}
   >
     <img
       className="rc-image-img"

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -47,4 +47,34 @@ describe('Basic', () => {
 
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
+  test('imgClass and imgStyle props should work', () => {
+    const wrapper = mount(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        imgClass="img"
+        imgStyle={{
+          objectFit: 'cover',
+        }}
+      />,
+    );
+    const imgWrapper = wrapper.find('img');
+    expect(imgWrapper.props().className).toContain('img');
+    expect(imgWrapper.props().style.objectFit).toEqual('cover');
+  });
+  // wrapper element will auto-scale to fit img element
+  test('width and height props should only be applied on img element', () => {
+    const wrapper = mount(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        height="400px"
+        width="400px"
+      />,
+    );
+    const img = wrapper.find('img');
+    const parentWrapper = img.parent();
+    expect(img.props().style.height).toEqual('400px');
+    expect(img.props().style.width).toEqual('400px');
+    expect(parentWrapper.props().style.width).toBeUndefined();
+    expect(parentWrapper.props().style.height).toBeUndefined();
+  });
 });

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -61,7 +61,7 @@ describe('Basic', () => {
     expect(img.props().className).toContain('img');
     expect(img.props().style.objectFit).toEqual('cover');
   });
-  test("wrapperClassName and wrapperStyle should work on image wrapper element",() => {
+  test('wrapperClassName and wrapperStyle should work on image wrapper element', () => {
     const wrapper = mount(
       <Image
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
@@ -71,24 +71,8 @@ describe('Basic', () => {
         }}
       />,
     );
-    const wrapperElement = wrapper.find('img').parent()
-    expect(wrapperElement.props().className).toContain("wrapper")
-    expect(wrapperElement.props().style.objectFit).toEqual("cover")
-  })
-  // wrapper element will auto-scale to fit img element
-  test('width and height props should only be applied on img element', () => {
-    const wrapper = mount(
-      <Image
-        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
-        height="400px"
-        width="400px"
-      />,
-    );
-    const img = wrapper.find('img');
-    const parentWrapper = img.parent();
-    expect(img.props().style.height).toEqual('400px');
-    expect(img.props().style.width).toEqual('400px');
-    expect(parentWrapper.props().style?.width).toBeUndefined();
-    expect(parentWrapper.props().style?.height).toBeUndefined();
+    const wrapperElement = wrapper.find('img').parent();
+    expect(wrapperElement.props().className).toContain('wrapper');
+    expect(wrapperElement.props().style.objectFit).toEqual('cover');
   });
 });

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -47,20 +47,34 @@ describe('Basic', () => {
 
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
-  test('imgClass and imgStyle props should work', () => {
+  test('className and style props should work on img element', () => {
     const wrapper = mount(
       <Image
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
-        imgClass="img"
-        imgStyle={{
+        className="img"
+        style={{
           objectFit: 'cover',
         }}
       />,
     );
-    const imgWrapper = wrapper.find('img');
-    expect(imgWrapper.props().className).toContain('img');
-    expect(imgWrapper.props().style.objectFit).toEqual('cover');
+    const img = wrapper.find('img');
+    expect(img.props().className).toContain('img');
+    expect(img.props().style.objectFit).toEqual('cover');
   });
+  test("wrapperClassName and wrapperStyle should work on image wrapper element",() => {
+    const wrapper = mount(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        wrapperClassName="wrapper"
+        wrapperStyle={{
+          objectFit: 'cover',
+        }}
+      />,
+    );
+    const wrapperElement = wrapper.find('img').parent()
+    expect(wrapperElement.props().className).toContain("wrapper")
+    expect(wrapperElement.props().style.objectFit).toEqual("cover")
+  })
   // wrapper element will auto-scale to fit img element
   test('width and height props should only be applied on img element', () => {
     const wrapper = mount(
@@ -74,7 +88,7 @@ describe('Basic', () => {
     const parentWrapper = img.parent();
     expect(img.props().style.height).toEqual('400px');
     expect(img.props().style.width).toEqual('400px');
-    expect(parentWrapper.props().style.width).toBeUndefined();
-    expect(parentWrapper.props().style.height).toBeUndefined();
+    expect(parentWrapper.props().style?.width).toBeUndefined();
+    expect(parentWrapper.props().style?.height).toBeUndefined();
   });
 });


### PR DESCRIPTION
1. width and height should only be applied on img element
parent element will auto-scale
2. add imgStyle and imgClass

close [#26996](https://github.com/ant-design/ant-design/issues/26996)