### PR TITLE
Added functionality for zoom in\out by sliding the wheel

### DIFF
--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -178,9 +178,7 @@ const Preview: React.FC<PreviewProps> = props => {
   };
 
   const onWheelMove: React.WheelEventHandler<HTMLBodyElement> = event => {
-    if (!visible) {
-      return;
-    }
+    if (!visible) return;
     event.preventDefault();
     const wheelDirection = event.deltaY;
     setLastWheelZoomDirection(wheelDirection);

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -178,6 +178,9 @@ const Preview: React.FC<PreviewProps> = props => {
   };
 
   const onWheelMove: React.WheelEventHandler<HTMLBodyElement> = event => {
+    if (!visible) {
+      return;
+    }
     event.preventDefault();
     const wheelDirection = event.deltaY;
     setLastWheelZoomDirection(wheelDirection);

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -55,7 +55,7 @@ const Preview: React.FC<PreviewProps> = props => {
   const currentPreviewIndex = previewUrlsKeys.indexOf(current);
   const combinationSrc = isPreviewGroup ? previewUrls.get(current) : src;
   const showLeftOrRightSwitches = isPreviewGroup && previewGroupCount > 1;
-  const [lastWheelZoomDirection, setLastWheelZoomDirection] = React.useState(0);
+  const [lastWheelZoomDirection, setLastWheelZoomDirection] = React.useState({});
 
   const onAfterClose = () => {
     setScale(1);
@@ -181,13 +181,14 @@ const Preview: React.FC<PreviewProps> = props => {
     if (!visible) return;
     event.preventDefault();
     const wheelDirection = event.deltaY;
-    setLastWheelZoomDirection(wheelDirection);
+    setLastWheelZoomDirection({ wheelDirection });
   };
 
   useEffect(() => {
-    if (lastWheelZoomDirection > 0) {
+    const { wheelDirection } = lastWheelZoomDirection;
+    if (wheelDirection > 0) {
       onZoomOut();
-    } else if (lastWheelZoomDirection < 0) {
+    } else if (wheelDirection < 0) {
       onZoomIn();
     }
   }, [lastWheelZoomDirection]);

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -55,7 +55,7 @@ const Preview: React.FC<PreviewProps> = props => {
   const currentPreviewIndex = previewUrlsKeys.indexOf(current);
   const combinationSrc = isPreviewGroup ? previewUrls.get(current) : src;
   const showLeftOrRightSwitches = isPreviewGroup && previewGroupCount > 1;
-  const [lastWheelZoomDirection, setLastWheelZoomDirection] = React.useState({});
+  const [lastWheelZoomDirection, setLastWheelZoomDirection] = React.useState({ wheelDirection: 0 });
 
   const onAfterClose = () => {
     setScale(1);

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -153,6 +153,28 @@ describe('Preview', () => {
     expect(wrapper.find('.rc-image-preview-img').prop('style')).toMatchObject({
       transform: 'scale3d(1, 1, 1) rotate(0deg)',
     });
+
+    act(() => {
+      const wheelEvent = new Event('wheel');
+      wheelEvent.deltaY = -50;
+      global.dispatchEvent(wheelEvent);
+      jest.runAllTimers();
+      wrapper.update();
+    });
+    expect(wrapper.find('.rc-image-preview-img').prop('style')).toMatchObject({
+      transform: 'scale3d(2, 2, 1) rotate(0deg)',
+    });
+
+    act(() => {
+      const wheelEvent = new Event('wheel');
+      wheelEvent.deltaY = 50;
+      global.dispatchEvent(wheelEvent);
+      jest.runAllTimers();
+      wrapper.update();
+    });
+    expect(wrapper.find('.rc-image-preview-img').prop('style')).toMatchObject({
+      transform: 'scale3d(1, 1, 1) rotate(0deg)',
+    });
   });
 
   it('Mouse Event', () => {


### PR DESCRIPTION
Listening to wheel event the determine the direction of the scrolling, and by that decide if zooming in or out.

This PR was opened due to this Feature Request in Ant Design repository's  issues: 
https://github.com/ant-design/ant-design/issues/28415

After this PR will be merged and a new version will be released I'll open a PR for Ant Design to integrate this new feature.