### PR TITLE
feat: add children prop instead img

### DIFF
--- a/docs/examples/basic.tsx
+++ b/docs/examples/basic.tsx
@@ -46,6 +46,14 @@ export default function Base() {
         width={200}
         height={100}
       />
+
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        width={200}
+        height={100}
+      >
+        <a>查看示例</a>
+      </Image>
     </div>
   );
 }

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -35,6 +35,7 @@ export interface ImageProps
   placeholder?: React.ReactNode;
   fallback?: string;
   preview?: boolean | ImagePreviewType;
+  children?: React.ReactNode;
   /**
    * @deprecated since version 3.2.1
    */
@@ -66,6 +67,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
   onError: onImageError,
   wrapperClassName,
   wrapperStyle,
+  children,
 
   // Img
   crossOrigin,
@@ -229,26 +231,32 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
           ...wrapperStyle,
         }}
       >
-        <img
-          {...imgCommonProps}
-          ref={getImgRef}
-          {...(isError && fallback
-            ? {
-                src: fallback,
-              }
-            : { onLoad, onError, src: imgSrc })}
-        />
+        {
+          children || (
+            <>
+              <img
+                {...imgCommonProps}
+                ref={getImgRef}
+                {...(isError && fallback
+                  ? {
+                    src: fallback,
+                  }
+                  : { onLoad, onError, src: imgSrc })}
+              />
 
-        {status === 'loading' && (
-          <div aria-hidden="true" className={`${prefixCls}-placeholder`}>
-            {placeholder}
-          </div>
-        )}
+              {status === 'loading' && (
+                <div aria-hidden="true" className={`${prefixCls}-placeholder`}>
+                  {placeholder}
+                </div>
+              )}
 
-        {/* Preview Click Mask */}
-        {previewMask && canPreview && (
-          <div className={cn(`${prefixCls}-mask`, maskClassName)}>{previewMask}</div>
-        )}
+              {/* Preview Click Mask */}
+              {previewMask && canPreview && (
+                <div className={cn(`${prefixCls}-mask`, maskClassName)}>{previewMask}</div>
+              )}
+            </>
+          )
+        }
       </div>
       {!isPreviewGroup && canPreview && (
         <Preview


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17774285/121900469-0636c180-cd58-11eb-8449-e1a38fd1f51c.png)
目前有一些场景需要自定义点击预览的trigger，不需要默认的图片，比如上述图片，需要点击查看预览来弹出预览图，所以增加了children这个prop。