### PR TITLE
feat:enable the left or right keyboard to switch image

### DIFF
--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
+import KeyCode from 'rc-util/lib/KeyCode';
 import Image from '../src';
 
 describe('Preview', () => {
@@ -21,10 +22,7 @@ describe('Preview', () => {
     );
 
     act(() => {
-      wrapper
-        .find('.rc-image')
-        .at(0)
-        .simulate('click');
+      wrapper.find('.rc-image').at(0).simulate('click');
       jest.runAllTimers();
       wrapper.update();
     });
@@ -44,10 +42,7 @@ describe('Preview', () => {
     );
 
     act(() => {
-      wrapper
-        .find('.rc-image')
-        .at(0)
-        .simulate('click');
+      wrapper.find('.rc-image').at(0).simulate('click');
       jest.runAllTimers();
       wrapper.update();
     });
@@ -65,10 +60,7 @@ describe('Preview', () => {
     );
 
     act(() => {
-      wrapper
-        .find('.rc-image')
-        .at(0)
-        .simulate('click');
+      wrapper.find('.rc-image').at(0).simulate('click');
       jest.runAllTimers();
       wrapper.update();
     });
@@ -96,6 +88,28 @@ describe('Preview', () => {
     expect(
       wrapper.find('.rc-image-preview .rc-image-preview-switch-left-disabled').get(0),
     ).toBeTruthy();
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { keyCode: KeyCode.RIGHT });
+      global.dispatchEvent(event);
+      jest.runAllTimers();
+      wrapper.update();
+    });
+
+    expect(
+      wrapper.find('.rc-image-preview .rc-image-preview-switch-right-disabled').get(0),
+    ).toBeTruthy();
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', { keyCode: KeyCode.LEFT });
+      global.dispatchEvent(event);
+      jest.runAllTimers();
+      wrapper.update();
+    });
+
+    expect(
+      wrapper.find('.rc-image-preview .rc-image-preview-switch-left-disabled').get(0),
+    ).toBeTruthy();
   });
 
   it('With Controlled', () => {
@@ -113,11 +127,6 @@ describe('Preview', () => {
       wrapper.update();
     });
 
-    expect(
-      wrapper
-        .find('.rc-image-preview')
-        .at(0)
-        .render(),
-    ).toMatchSnapshot();
+    expect(wrapper.find('.rc-image-preview').at(0).render()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION

[[English Template / 英文模板](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE.md)]

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |      When the picture is previewed, you can use the left and right arrow keys to switch    |
| 🇨🇳 中文 |     图片预览时, 可使用左右方向键进行切换     |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供