### PR TITLE
fix: only one group item should have operation-process

### DIFF
--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -74,6 +74,7 @@ const Preview: React.FC<PreviewProps> = props => {
   const currentPreviewIndex = previewUrlsKeys.indexOf(current);
   const combinationSrc = isPreviewGroup ? previewUrls.get(current) : src;
   const showLeftOrRightSwitches = isPreviewGroup && previewGroupCount > 1;
+  const showOperationsProgress = isPreviewGroup && previewGroupCount >= 1;
   const [lastWheelZoomDirection, setLastWheelZoomDirection] = useState({ wheelDirection: 0 });
 
   const onAfterClose = () => {
@@ -302,7 +303,7 @@ const Preview: React.FC<PreviewProps> = props => {
       {...restProps}
     >
       <ul className={`${prefixCls}-operations`}>
-        {showLeftOrRightSwitches && (
+        {showOperationsProgress && (
           <li className={`${prefixCls}-operations-progress`}>
             {countRender?.(currentPreviewIndex + 1, previewGroupCount) ??
               `${currentPreviewIndex + 1} / ${previewGroupCount}`}
@@ -317,7 +318,7 @@ const Preview: React.FC<PreviewProps> = props => {
             key={type}
           >
             {React.isValidElement(icon)
-              ? React.cloneElement(icon, { className: iconClassName })
+              ? React.cloneElement<{ className?: string }>(icon, { className: iconClassName })
               : icon}
           </li>
         ))}

--- a/tests/__snapshots__/previewGroup.test.tsx.snap
+++ b/tests/__snapshots__/previewGroup.test.tsx.snap
@@ -21,6 +21,11 @@ exports[`PreviewGroup With Controlled 1`] = `
         class="rc-image-preview-operations"
       >
         <li
+          class="rc-image-preview-operations-progress"
+        >
+          1 / 1
+        </li>
+        <li
           class="rc-image-preview-operations-operation"
         />
         <li


### PR DESCRIPTION
我认为，正如这个[issue](https://github.com/ant-design/ant-design/issues/37243)所描述的那样，哪怕仅有 `PrviewGroup` 下仅有一个 `Image` 时，也应该可以看标题