### PR TITLE
fix: operations are overridden when their opacity is not 1

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -134,6 +134,11 @@
       -webkit-overflow-scrolling: touch;
     }
 
+    &-operations-wrapper {
+      position: fixed;
+      z-index: @zindex-preview-mask + 1;
+    }
+
     &-operations {
       .reset;
       pointer-events: auto;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint src/ --ext .ts,.tsx,.jsx,.js,.md",
     "prettier": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "test": "rc-test",
-    "coverage": "father test --coverage",
+    "coverage": "rc-test --coverage",
     "now-build": "npm run docs:build"
   },
   "peerDependencies": {

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -371,7 +371,7 @@ const Preview: React.FC<PreviewProps> = props => {
       <CSSMotion visible={visible} motionName={maskTransitionName}>
         {({ className, style }) => (
           <div
-            className={classnames(className, rootClassName)}
+            className={classnames(`${prefixCls}-operations-wrapper`, className, rootClassName)}
             style={style}
           >
             {operations}

--- a/tests/__snapshots__/preview.test.tsx.snap
+++ b/tests/__snapshots__/preview.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
       />
     </div>
     <div
-      class="custom-className"
+      class="rc-image-preview-operations-wrapper custom-className"
     >
       <ul
         class="rc-image-preview-operations"


### PR DESCRIPTION
`operations`（操作条）在过渡动画运行中 `opacity`（透明度）不为 `1` 时，会被 fixed 定位且层级高的 dom 遮挡

https://user-images.githubusercontent.com/38420763/200565420-8f551967-ad31-46d6-9777-20432d2936ed.mov

以下代码可以复现上面的场景：
```html
<!DOCTYPE html>
<html lang="en">
<style>
  div{
    width: 100px;
    height: 100px;
  } 
  #a {
    background:red;
    position: fixed;
    top: 0;
    z-index: 9999;
  } 
  #b {
    background:blue;
    position: fixed;
    left: 20px;
    top: 20px;
    z-index: 9;
  } 
  #c {
    background:green;
    left: 40px;
    top: 40px;
    position: fixed;
    z-index: 10;
  } 
</style>
<body>
  <!-- <div style="opacity: 0.9; position: fixed; z-index: 9999;">
    <div id="a">1-可覆盖其他</div> 
  </div> -->
  <div style="opacity: 0.9">
    <div id="a">1-被遮挡</div> 
  </div>
  <div id="b">2</div> 
  <div id="c">3</div> 
</body>
</html>
```