### PR TITLE
fix: operations are not displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
+    "@rc-component/portal": "^1.0.2",
     "classnames": "^2.2.6",
     "rc-dialog": "~9.0.0",
     "rc-util": "^5.0.6"

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Portal from '@rc-component/portal';
 import type { DialogProps as IDialogPropTypes } from 'rc-dialog';
 import Dialog from 'rc-dialog';
 import CSSMotion from 'rc-motion';
@@ -45,6 +46,7 @@ const Preview: React.FC<PreviewProps> = props => {
     visible,
     icons = {},
     rootClassName,
+    getContainer,
     countRender,
     scaleStep = 0.5,
     transitionName = 'zoom',
@@ -349,6 +351,7 @@ const Preview: React.FC<PreviewProps> = props => {
         visible={visible}
         wrapClassName={wrapClassName}
         rootClassName={rootClassName}
+        getContainer={getContainer}
         {...restProps}
       >
         <div
@@ -370,12 +373,14 @@ const Preview: React.FC<PreviewProps> = props => {
       </Dialog>
       <CSSMotion visible={visible} motionName={maskTransitionName}>
         {({ className, style }) => (
-          <div
-            className={classnames(`${prefixCls}-operations-wrapper`, className, rootClassName)}
-            style={style}
-          >
-            {operations}
-          </div>
+          <Portal open getContainer={getContainer}>
+            <div
+              className={classnames(`${prefixCls}-operations-wrapper`, className, rootClassName)}
+              style={style}
+            >
+              {operations}
+            </div>
+          </Portal>
         )}
       </CSSMotion>
     </>

--- a/tests/__snapshots__/preview.test.tsx.snap
+++ b/tests/__snapshots__/preview.test.tsx.snap
@@ -22,29 +22,6 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
       />
     </div>
-    <div
-      class="rc-image-preview-operations-wrapper custom-className"
-    >
-      <ul
-        class="rc-image-preview-operations"
-      >
-        <li
-          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-close"
-        />
-        <li
-          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomIn"
-        />
-        <li
-          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomOut rc-image-preview-operations-operation-disabled"
-        />
-        <li
-          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateRight"
-        />
-        <li
-          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateLeft"
-        />
-      </ul>
-    </div>
   </div>,
   <div>
     <div
@@ -92,6 +69,31 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
           />
         </div>
       </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      class="rc-image-preview-operations-wrapper custom-className"
+    >
+      <ul
+        class="rc-image-preview-operations"
+      >
+        <li
+          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-close"
+        />
+        <li
+          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomIn"
+        />
+        <li
+          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomOut rc-image-preview-operations-operation-disabled"
+        />
+        <li
+          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateRight"
+        />
+        <li
+          class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateLeft"
+        />
+      </ul>
     </div>
   </div>,
 ]


### PR DESCRIPTION
`相册模式` 例子 `display: 'none'`  operations 会显示不出来

![image](https://user-images.githubusercontent.com/38420763/200897634-a28e30ff-3b3b-4ad0-bee7-14ef831766b5.png)

![image](https://user-images.githubusercontent.com/38420763/201468926-d9f345ff-f69b-4910-b279-5a3d66ab9f8b.png)

![image](https://user-images.githubusercontent.com/38420763/201468942-1add7937-7ec3-43b1-ab93-ed8996187947.png)
