### PR TITLE
refactor(): :necktie: 缩小图片支持小于1

### DIFF
--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -94,7 +94,7 @@ const Preview: React.FC<PreviewProps> = props => {
   };
 
   const onZoomOut = () => {
-    if (scale > 1) {
+    if (scale - scaleStep > 0) {
       setScale(value => value - scaleStep);
     }
     setPosition(initialPosition);

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -146,7 +146,7 @@ const Preview: React.FC<PreviewProps> = props => {
       icon: zoomOut,
       onClick: onZoomOut,
       type: 'zoomOut',
-      disabled: scale === 1,
+      disabled: scale - scaleStep <= 0,
     },
     {
       icon: rotateRight,

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -150,6 +150,23 @@ describe('Preview', () => {
       jest.runAllTimers();
     });
     expect(document.querySelector('.rc-image-preview-img')).toHaveStyle({
+      transform: 'scale3d(0.5, 0.5, 1) rotate(0deg)',
+    });
+
+    // can not be scale 0 
+    fireEvent.click(document.querySelectorAll('.rc-image-preview-operations-operation')[2]);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(document.querySelector('.rc-image-preview-img')).toHaveStyle({
+      transform: 'scale3d(0.5, 0.5, 1) rotate(0deg)',
+    });
+
+    fireEvent.click(document.querySelectorAll('.rc-image-preview-operations-operation')[1]);
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(document.querySelector('.rc-image-preview-img')).toHaveStyle({
       transform: 'scale3d(1, 1, 1) rotate(0deg)',
     });
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/react-component/image/issues/110

### 💡 需求背景和解决方案

图片缩小比例允许小于1，并且大于0。  
有时候查看一张尺寸非常大的图片，还是有需要缩小的场景的。  

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
