### PR TITLE
fix: window system mouse zooming too slow

### DIFF
--- a/src/previewConfig.ts
+++ b/src/previewConfig.ts
@@ -6,4 +6,4 @@ export const MAX_SCALE = 50;
 /** Scale the ratio base */
 export const BASE_SCALE_RATIO = 1;
 /** The maximum zoom ratio when the mouse zooms in, adjustable */
-export const WHEEL_MAX_SCALE_RATIO = 0.2;
+export const WHEEL_MAX_SCALE_RATIO = 1;

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -220,7 +220,7 @@ describe('Preview', () => {
       jest.runAllTimers();
     });
     expect(document.querySelector('.rc-image-preview-img')).toHaveStyle({
-      transform: 'translate3d(0px, 0px, 0) scale3d(1.1, 1.1, 1) rotate(0deg)',
+      transform: 'translate3d(0px, 0px, 0) scale3d(1.25, 1.25, 1) rotate(0deg)',
     });
 
     fireEvent.wheel(document.querySelector('.rc-image-preview-img'), {
@@ -293,7 +293,7 @@ describe('Preview', () => {
       jest.runAllTimers();
     });
     expect(document.querySelector('.rc-image-preview-img')).toHaveStyle({
-      transform: 'translate3d(0px, 0px, 0) scale3d(1.2, 1.2, 1) rotate(0deg)',
+      transform: 'translate3d(0px, 0px, 0) scale3d(1.5, 1.5, 1) rotate(0deg)',
     });
 
     fireEvent.wheel(document.querySelector('.rc-image-preview-img'), {
@@ -554,7 +554,7 @@ describe('Preview', () => {
     fireMouseEvent('mouseUp', window);
 
     expect(document.querySelector('.rc-image-preview-img')).toHaveStyle({
-      transform: 'translate3d(-10px, -65px, 0) scale3d(1.1, 1.1, 1) rotate(0deg)',
+      transform: 'translate3d(-85px, -65px, 0) scale3d(1.25, 1.25, 1) rotate(0deg)',
     });
 
     // Clear


### PR DESCRIPTION
修复在 window 系统鼠标缩放过慢，鼠标滚动时 onWheel 事件 event.deltaY 的值在 widnows 与 mac 两个系统中存在差异

before：
onWheel 事件单次缩放比例最大限制 0.2 * scaleStep(0.5) = 0.1，在windows系统用鼠标 0.1 倍的缩放会导致很慢
after:
onWheel 事件单次缩放比例最大限制 1 * scaleStep(0.5) = 0.5，刚好是 scaleStep 的值，0.5 倍的缩放
