### PR TITLE
fix: when pass getContainer into preview , the preview panel should be rendered into target container

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -77,7 +77,7 @@
     }
 
     &-mask {
-      position: fixed;
+      position: absolute;
       top: 0;
       right: 0;
       bottom: 0;
@@ -122,7 +122,7 @@
     }
 
     &-wrap {
-      position: fixed;
+      position: absolute;
       top: 0;
       right: 0;
       bottom: 0;
@@ -134,15 +134,19 @@
     }
 
     &-operations-wrapper {
-      position: fixed;
+      position: absolute;
       z-index: @zindex-preview-mask + 1;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      top: 0;
     }
 
     &-operations {
       .reset;
       pointer-events: auto;
       list-style: none;
-      position: fixed;
+      position: absolute;
       display: flex;
       top: 0;
       right: 0;
@@ -177,7 +181,7 @@
     }
 
     &-switch-left {
-      position: fixed;
+      position: absolute;
       left: 10px;
       top: 50%;
       width: 44px;
@@ -206,7 +210,7 @@
     }
 
     &-switch-right {
-      position: fixed;
+      position: absolute;
       right: 10px;
       top: 50%;
       width: 44px;

--- a/docs/demo/getContainer.md
+++ b/docs/demo/getContainer.md
@@ -1,0 +1,8 @@
+---
+title: getContainer
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/getContainer.tsx"></code>

--- a/docs/examples/getContainer.tsx
+++ b/docs/examples/getContainer.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable global-require */
+import * as React from 'react';
+import Image from 'rc-image';
+import '../../assets/index.less';
+
+export default function PreviewGroup() {
+  const container = React.useRef(null);
+  return (
+    <div className='container' ref={container}>
+      <Image.PreviewGroup
+        preview={{
+          getContainer: () => container.current,
+          countRender: (current, total) => `第${current}张 / 总共${total}张`,
+          onChange: (current, prev) => console.log(`当前第${current}张，上一次第${prev === undefined ? '-' : prev}张`)
+        }}
+      >
+        <Image wrapperStyle={{ marginRight: 24, width: 200 }} src={require('./images/1.jpeg')} />
+        <Image
+          wrapperStyle={{ marginRight: 24, width: 200 }}
+          preview={false}
+          src={require('./images/disabled.jpeg')}
+        />
+        <Image wrapperStyle={{ marginRight: 24, width: 200 }} src={require('./images/2.jpeg')} />
+        <Image wrapperStyle={{ marginRight: 24, width: 200 }} src={require('./images/3.jpeg')} />
+        <Image wrapperStyle={{ marginRight: 24, width: 200 }} src="error" alt="error" />
+        <Image wrapperStyle={{ marginRight: 24, width: 200 }} src={require('./images/1.jpeg')} />
+      </Image.PreviewGroup>
+    </div>
+  );
+}

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -1,13 +1,13 @@
+import * as React from 'react';
+import { useState } from 'react';
 import cn from 'classnames';
-import type { IDialogPropTypes } from 'rc-dialog/lib/IDialogPropTypes';
 import { getOffset } from 'rc-util/lib/Dom/css';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { GetContainer } from 'rc-util/lib/PortalWrapper';
-import * as React from 'react';
-import { useState } from 'react';
 import type { PreviewProps } from './Preview';
 import Preview from './Preview';
 import PreviewGroup, { context } from './PreviewGroup';
+import type { IDialogPropTypes } from 'rc-dialog/lib/IDialogPropTypes';
 
 export interface ImagePreviewType
   extends Omit<
@@ -234,7 +234,6 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
       ...style,
     },
   };
-
 
   return (
     <>

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
-import { useState } from 'react';
 import cn from 'classnames';
+import type { IDialogPropTypes } from 'rc-dialog/lib/IDialogPropTypes';
 import { getOffset } from 'rc-util/lib/Dom/css';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { GetContainer } from 'rc-util/lib/PortalWrapper';
+import * as React from 'react';
+import { useState } from 'react';
 import type { PreviewProps } from './Preview';
 import Preview from './Preview';
 import PreviewGroup, { context } from './PreviewGroup';
-import type { IDialogPropTypes } from 'rc-dialog/lib/IDialogPropTypes';
 
 export interface ImagePreviewType
   extends Omit<
@@ -234,6 +234,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
       ...style,
     },
   };
+
 
   return (
     <>

--- a/src/Operations.tsx
+++ b/src/Operations.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
 import classnames from 'classnames';
 import CSSMotion from 'rc-motion';
-import Portal from '@rc-component/portal';
-import { MIN_SCALE, MAX_SCALE } from './previewConfig';
+import * as React from 'react';
 import type { PreviewProps } from './Preview';
+import { MAX_SCALE, MIN_SCALE } from './previewConfig';
 
 interface OperationsProps
   extends Pick<
@@ -32,11 +31,10 @@ interface OperationsProps
   onFlipY: () => void;
 }
 
-const Operations: React.FC<OperationsProps> = (props) => {
+const Operations: React.FC<OperationsProps> = props => {
   const {
     visible,
     maskTransitionName,
-    getContainer,
     prefixCls,
     rootClassName,
     icons,
@@ -54,7 +52,7 @@ const Operations: React.FC<OperationsProps> = (props) => {
     onRotateRight,
     onRotateLeft,
     onFlipX,
-    onFlipY
+    onFlipY,
   } = props;
   const { rotateLeft, rotateRight, zoomIn, zoomOut, close, left, right, flipX, flipY } = icons;
   const toolClassName = `${prefixCls}-operations-operation`;
@@ -124,8 +122,7 @@ const Operations: React.FC<OperationsProps> = (props) => {
       <ul className={`${prefixCls}-operations`}>
         {showProgress && (
           <li className={`${prefixCls}-operations-progress`}>
-            {countRender?.(current + 1, count) ??
-              `${current + 1} / ${count}`}
+            {countRender?.(current + 1, count) ?? `${current + 1} / ${count}`}
           </li>
         )}
         {tools.map(({ icon, onClick, type, disabled }) => (
@@ -149,14 +146,12 @@ const Operations: React.FC<OperationsProps> = (props) => {
   return (
     <CSSMotion visible={visible} motionName={maskTransitionName}>
       {({ className, style }) => (
-        <Portal open getContainer={getContainer ?? document.body}>
-          <div
-            className={classnames(`${prefixCls}-operations-wrapper`, className, rootClassName)}
-            style={style}
-          >
-            {operations}
-          </div>
-        </Portal>
+        <div
+          className={classnames(`${prefixCls}-operations-wrapper`, className, rootClassName)}
+          style={style}
+        >
+          {operations}
+        </div>
       )}
     </CSSMotion>
   );

--- a/src/Operations.tsx
+++ b/src/Operations.tsx
@@ -1,8 +1,8 @@
+import * as React from 'react';
 import classnames from 'classnames';
 import CSSMotion from 'rc-motion';
-import * as React from 'react';
+import { MIN_SCALE, MAX_SCALE } from './previewConfig';
 import type { PreviewProps } from './Preview';
-import { MAX_SCALE, MIN_SCALE } from './previewConfig';
 
 interface OperationsProps
   extends Pick<
@@ -31,7 +31,7 @@ interface OperationsProps
   onFlipY: () => void;
 }
 
-const Operations: React.FC<OperationsProps> = props => {
+const Operations: React.FC<OperationsProps> = (props) => {
   const {
     visible,
     maskTransitionName,
@@ -52,7 +52,7 @@ const Operations: React.FC<OperationsProps> = props => {
     onRotateRight,
     onRotateLeft,
     onFlipX,
-    onFlipY,
+    onFlipY
   } = props;
   const { rotateLeft, rotateRight, zoomIn, zoomOut, close, left, right, flipX, flipY } = icons;
   const toolClassName = `${prefixCls}-operations-operation`;
@@ -122,7 +122,8 @@ const Operations: React.FC<OperationsProps> = props => {
       <ul className={`${prefixCls}-operations`}>
         {showProgress && (
           <li className={`${prefixCls}-operations-progress`}>
-            {countRender?.(current + 1, count) ?? `${current + 1} / ${count}`}
+            {countRender?.(current + 1, count) ??
+              `${current + 1} / ${count}`}
           </li>
         )}
         {tools.map(({ icon, onClick, type, disabled }) => (

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -293,30 +293,30 @@ const Preview: React.FC<PreviewProps> = props => {
             }}
           />
         </div>
+        <Operations
+          visible={visible}
+          maskTransitionName={maskTransitionName}
+          getContainer={getContainer}
+          prefixCls={prefixCls}
+          rootClassName={rootClassName}
+          icons={icons}
+          countRender={countRender}
+          showSwitch={showLeftOrRightSwitches}
+          showProgress={showOperationsProgress}
+          current={currentPreviewIndex}
+          count={previewGroupCount}
+          scale={scale}
+          onSwitchLeft={onSwitchLeft}
+          onSwitchRight={onSwitchRight}
+          onZoomIn={onZoomIn}
+          onZoomOut={onZoomOut}
+          onRotateRight={onRotateRight}
+          onRotateLeft={onRotateLeft}
+          onFlipX={onFlipX}
+          onFlipY={onFlipY}
+          onClose={onClose}
+        />
       </Dialog>
-      <Operations
-        visible={visible}
-        maskTransitionName={maskTransitionName}
-        getContainer={getContainer}
-        prefixCls={prefixCls}
-        rootClassName={rootClassName}
-        icons={icons}
-        countRender={countRender}
-        showSwitch={showLeftOrRightSwitches}
-        showProgress={showOperationsProgress}
-        current={currentPreviewIndex}
-        count={previewGroupCount}
-        scale={scale}
-        onSwitchLeft={onSwitchLeft}
-        onSwitchRight={onSwitchRight}
-        onZoomIn={onZoomIn}
-        onZoomOut={onZoomOut}
-        onRotateRight={onRotateRight}
-        onRotateLeft={onRotateLeft}
-        onFlipX={onFlipX}
-        onFlipY={onFlipY}
-        onClose={onClose}
-      />
     </>
   );
 };

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -77,7 +77,7 @@ const Group: React.FC<GroupConsumerProps> = ({
     ...dialogProps
   } = typeof preview === 'object' ? preview : {};
 
-  const mergedGetContainer = React.useMemo(() => {
+  const mergedGetContainer = React.useCallback(() => {
     if (!getContainer) return getContainer;
     let target: HTMLElement | null = null;
     if (typeof getContainer === 'string') {
@@ -179,7 +179,7 @@ const Group: React.FC<GroupConsumerProps> = ({
         mousePosition={mousePosition}
         src={canPreviewUrls.get(current)}
         icons={icons}
-        getContainer={mergedGetContainer}
+        getContainer={mergedGetContainer()}
         countRender={countRender}
         {...dialogProps}
       />

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -76,6 +76,23 @@ const Group: React.FC<GroupConsumerProps> = ({
     onChange = undefined,
     ...dialogProps
   } = typeof preview === 'object' ? preview : {};
+
+  const mergedGetContainer = React.useMemo(() => {
+    if (!getContainer) return getContainer;
+    let target: HTMLElement | null = null;
+    if (typeof getContainer === 'string') {
+      target = document.querySelector(getContainer);
+    } else if (typeof getContainer === 'function') {
+      target = getContainer();
+    } else {
+      target = getContainer;
+    }
+    if (!target) return target;
+    if (target.style.position === '' || target.style.position === 'static') {
+      target.style.position = 'relative';
+    }
+    return target;
+  }, [getContainer]);
   const [previewUrls, setPreviewUrls] = useState<Map<number, PreviewUrl>>(new Map());
   const previewUrlsKeys = Array.from(previewUrls.keys());
   const prevCurrent = React.useRef<number | undefined>();
@@ -162,7 +179,7 @@ const Group: React.FC<GroupConsumerProps> = ({
         mousePosition={mousePosition}
         src={canPreviewUrls.get(current)}
         icons={icons}
-        getContainer={getContainer}
+        getContainer={mergedGetContainer}
         countRender={countRender}
         {...dialogProps}
       />

--- a/tests/__snapshots__/controlled.test.tsx.snap
+++ b/tests/__snapshots__/controlled.test.tsx.snap
@@ -27,6 +27,35 @@ exports[`Controlled With previewVisible 1`] = `
           style="transform: translate3d(0px, 0px, 0) scale3d(1, 1, 1) rotate(0deg);"
         />
       </div>
+      <div
+        class="rc-image-preview-operations-wrapper"
+      >
+        <ul
+          class="rc-image-preview-operations"
+        >
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-close"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomIn"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomOut rc-image-preview-operations-operation-disabled"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateRight"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateLeft"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipX"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipY"
+          />
+        </ul>
+      </div>
     </div>
   </div>
   <div

--- a/tests/__snapshots__/preview.test.tsx.snap
+++ b/tests/__snapshots__/preview.test.tsx.snap
@@ -23,35 +23,6 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
       />
     </div>
   </div>,
-  <div
-    class="rc-image-preview-operations-wrapper custom-className"
-  >
-    <ul
-      class="rc-image-preview-operations"
-    >
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-close"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomIn"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomOut rc-image-preview-operations-operation-disabled"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateRight"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateLeft"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipX"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipY"
-      />
-    </ul>
-  </div>,
   <div>
     <div
       class="rc-image-preview-root custom-className"
@@ -87,6 +58,35 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
                   src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
                   style="transform: translate3d(0px, 0px, 0) scale3d(1, 1, 1) rotate(0deg);"
                 />
+              </div>
+              <div
+                class="rc-image-preview-operations-wrapper custom-className"
+              >
+                <ul
+                  class="rc-image-preview-operations"
+                >
+                  <li
+                    class="rc-image-preview-operations-operation rc-image-preview-operations-operation-close"
+                  />
+                  <li
+                    class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomIn"
+                  />
+                  <li
+                    class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomOut rc-image-preview-operations-operation-disabled"
+                  />
+                  <li
+                    class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateRight"
+                  />
+                  <li
+                    class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateLeft"
+                  />
+                  <li
+                    class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipX"
+                  />
+                  <li
+                    class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipY"
+                  />
+                </ul>
               </div>
             </div>
           </div>

--- a/tests/__snapshots__/preview.test.tsx.snap
+++ b/tests/__snapshots__/preview.test.tsx.snap
@@ -23,6 +23,35 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
       />
     </div>
   </div>,
+  <div
+    class="rc-image-preview-operations-wrapper custom-className"
+  >
+    <ul
+      class="rc-image-preview-operations"
+    >
+      <li
+        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-close"
+      />
+      <li
+        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomIn"
+      />
+      <li
+        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomOut rc-image-preview-operations-operation-disabled"
+      />
+      <li
+        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateRight"
+      />
+      <li
+        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateLeft"
+      />
+      <li
+        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipX"
+      />
+      <li
+        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipY"
+      />
+    </ul>
+  </div>,
   <div>
     <div
       class="rc-image-preview-root custom-className"
@@ -36,9 +65,8 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
       >
         <div
           aria-modal="true"
-          class="rc-image-preview zoom-appear zoom-appear-prepare zoom"
+          class="rc-image-preview"
           role="dialog"
-          style="transform-origin: 0px 0px;"
         >
           <div
             aria-hidden="true"
@@ -70,35 +98,6 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
         </div>
       </div>
     </div>
-  </div>,
-  <div
-    class="rc-image-preview-operations-wrapper custom-className"
-  >
-    <ul
-      class="rc-image-preview-operations"
-    >
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-close"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomIn"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomOut rc-image-preview-operations-operation-disabled"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateRight"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateLeft"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipX"
-      />
-      <li
-        class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipY"
-      />
-    </ul>
   </div>,
 ]
 `;

--- a/tests/__snapshots__/preview.test.tsx.snap
+++ b/tests/__snapshots__/preview.test.tsx.snap
@@ -36,8 +36,9 @@ exports[`Preview add rootClassName should be correct when open preview 1`] = `
       >
         <div
           aria-modal="true"
-          class="rc-image-preview"
+          class="rc-image-preview zoom-appear zoom-appear-prepare zoom"
           role="dialog"
+          style="transform-origin: 0px 0px;"
         >
           <div
             aria-hidden="true"

--- a/tests/__snapshots__/previewGroup.test.tsx.snap
+++ b/tests/__snapshots__/previewGroup.test.tsx.snap
@@ -27,6 +27,40 @@ exports[`PreviewGroup With Controlled 1`] = `
           style="transform: translate3d(0px, 0px, 0) scale3d(1, 1, 1) rotate(0deg);"
         />
       </div>
+      <div
+        class="rc-image-preview-operations-wrapper"
+      >
+        <ul
+          class="rc-image-preview-operations"
+        >
+          <li
+            class="rc-image-preview-operations-progress"
+          >
+            1 / 1
+          </li>
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-close"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomIn"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-zoomOut rc-image-preview-operations-operation-disabled"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateRight"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-rotateLeft"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipX"
+          />
+          <li
+            class="rc-image-preview-operations-operation rc-image-preview-operations-operation-flipY"
+          />
+        </ul>
+      </div>
     </div>
   </div>
   <div

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import KeyCode from 'rc-util/lib/KeyCode';
 import Image from '../src';
@@ -215,5 +216,70 @@ describe('PreviewGroup', () => {
     expect(document.querySelector('.rc-image-preview-img')).toHaveStyle({
       transform: 'translate3d(0px, 0px, 0) scale3d(1, 1, 1) rotate(0deg)',
     });
+  });
+
+  it('getContainer', () => {
+    const { container, rerender } = render(
+      <div className="container">
+        <Image.PreviewGroup preview={{ getContainer: '.container' }}>
+          <Image src="src1" />
+          <Image src="src2" />
+        </Image.PreviewGroup>
+      </div>,
+    );
+
+    fireEvent.click(container.querySelector('.rc-image'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(
+      document.querySelector('.container').querySelector('.rc-image-preview-root'),
+    ).toBeTruthy();
+
+    const App = () => {
+      const warp = React.useRef(null);
+      return (
+        <div className="container2" ref={warp}>
+          <Image.PreviewGroup preview={{ getContainer: () => warp.current }}>
+            <Image src="src1" />
+            <Image src="src2" />
+          </Image.PreviewGroup>
+        </div>
+      );
+    };
+    rerender(<App />);
+
+
+    fireEvent.click(container.querySelector('.rc-image'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(
+      document.querySelector('.container2').querySelector('.rc-image-preview-root'),
+    ).toBeTruthy();
+
+    const App2 = () => {
+      return (
+        <div className="container3">
+          <Image.PreviewGroup preview={{ getContainer: document.body }}>
+            <Image src="src1" />
+            <Image src="src2" />
+          </Image.PreviewGroup>
+        </div>
+      );
+    };
+    rerender(<App2 />);
+
+
+    fireEvent.click(container.querySelector('.rc-image'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(
+      document.querySelector('body').querySelector('.rc-image-preview-root'),
+    ).toBeTruthy();
   });
 });

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import KeyCode from 'rc-util/lib/KeyCode';
+import React from 'react';
 import Image from '../src';
 
 describe('PreviewGroup', () => {
@@ -228,6 +228,9 @@ describe('PreviewGroup', () => {
       </div>,
     );
 
+    act(() => {
+      jest.runAllTimers();
+    });
     fireEvent.click(container.querySelector('.rc-image'));
     act(() => {
       jest.runAllTimers();
@@ -250,7 +253,9 @@ describe('PreviewGroup', () => {
     };
     rerender(<App />);
 
-
+    act(() => {
+      jest.runAllTimers();
+    });
     fireEvent.click(container.querySelector('.rc-image'));
     act(() => {
       jest.runAllTimers();
@@ -271,15 +276,15 @@ describe('PreviewGroup', () => {
       );
     };
     rerender(<App2 />);
-
+    act(() => {
+      jest.runAllTimers();
+    });
 
     fireEvent.click(container.querySelector('.rc-image'));
     act(() => {
       jest.runAllTimers();
     });
 
-    expect(
-      document.querySelector('body').querySelector('.rc-image-preview-root'),
-    ).toBeTruthy();
+    expect(document.querySelector('body').querySelector('.rc-image-preview-root')).toBeTruthy();
   });
 });


### PR DESCRIPTION
- https://github.com/ant-design/ant-design/discussions/42840

After:

<img width="916" alt="image" src="https://github.com/react-component/image/assets/10286961/95ca6357-3f49-428a-bc75-ebcea6737fa8">
