### PR TITLE
feat: support imageRender

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,39 +74,16 @@ export default () => (
 
 ### PreviewType
 
-```typescript
-{
-  visible?: boolean;
-  scaleStep?: number;
-  onVisibleChange?: (visible: boolean, prevVisible: boolean) => void;
-  onTransform: (params: {
-    transform: { x: number, y: number, rotate: number, scale: number, flipX: boolean, flipY: boolean },
-    action: 'flipY' | 'flipX' | 'rotateLeft' | 'rotateRight' | 'zoomIn' | 'zoomOut' | 'close' | 'switch' | 'wheel' | 'doubleClick' | 'move' | 'dragRebound'
-  )} => void;
-  getContainer?: string | HTMLElement | (() => HTMLElement) | false;
-  toolbarRender?: (params: {
-    originalNode: React.ReactNode;
-    icons: {
-      flipYIcon: React.ReactNode;
-      flipXIcon: React.ReactNode;
-      rotateLeftIcon: React.ReactNode;
-      rotateRightIcon: React.ReactNode;
-      zoomOutIcon: React.ReactNode;
-      zoomInIcon: React.ReactNode;
-      closeIcon: React.ReactNode;
-    };
-    actions: {
-      flipY: () => void;
-      flipX: () => void;
-      rotateLeft: () => void;
-      rotateRight: () => void;
-      zoomOut: () => void;
-      zoomIn: () => void;
-      close: () => void;
-    };
-  }) => React.ReactNode }
-}
-```
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| visible | boolean | - | Whether the preview is open or not |
+| scaleStep | number | 0.5 | The number to which the scale is increased or decreased |
+| forceRender | boolean | - | Force render preview |
+| getContainer | string \| HTMLElement \| (() => HTMLElement) \| false | document.body | Return the mount node for preview |
+| imageRender | { originalNode: React.ReactNode, transform: [TransformType](#TransformType) } => React.ReactNode | - | Customize image |
+| toolbarRender | (params: Omit<[ToolbarRenderType](#ToolbarRenderType), 'current' \| 'total'>) => React.ReactNode | - | Customize toolbar |
+| onVisibleChange | (visible: boolean, prevVisible: boolean) => void | - | Callback when visible is changed |
+| onTransform | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | Callback when transform is changed |
 
 ## Image.PreviewGroup
 
@@ -133,41 +110,76 @@ export default () => (
 
 ### PreviewGroupType
 
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| visible | boolean | - | Whether the preview is open or not |
+| current | number | - | current index |
+| scaleStep | number | 0.5 | The number to which the scale is increased or decreased |
+| forceRender | boolean | - | Force render preview |
+| getContainer | string \| HTMLElement \| (() => HTMLElement) \| false | document.body | Return the mount node for preview |
+| countRender | (current: number, total: number) => string | - | Customize count |
+| imageRender | { originalNode: React.ReactNode, transform: [TransformType](#TransformType), current: number } => React.ReactNode | - | Customize image |
+| toolbarRender | (params: [ToolbarRenderType](#ToolbarRenderType)) => React.ReactNode | - | Customize toolbar |
+| onVisibleChange | (visible: boolean, prevVisible: boolean, current: number) => void | - | Callback when visible is changed |
+| onTransform | { transform: [TransformType](#TransformType), action: [TransformAction](#TransformAction) } | - | Callback when transform is changed |
+
+### TransformType
+
 ```typescript
 {
-  visible?: boolean;
-  scaleStep?: number;
-  onVisibleChange?: (visible, prevVisible, current: number) => void;
-  onTransform: (params: {
-    transform: { x: number, y: number, rotate: number, scale: number, flipX: boolean, flipY: boolean },
-    action: 'flipY' | 'flipX' | 'rotateLeft' | 'rotateRight' | 'zoomIn' | 'zoomOut' | 'close' | 'switch' | 'wheel' | 'doubleClick' | 'move' | 'dragRebound'
-  )} => void;
-  getContainer?: string | HTMLElement | (() => HTMLElement) | false;
-  countRender?: (current: number, total: number) => string;
-  current?: number;
-  toolbarRender?: (params: {
-    originalNode: React.ReactNode;
-    icons: {
-      flipYIcon: React.ReactNode;
-      flipXIcon: React.ReactNode;
-      rotateLeftIcon: React.ReactNode;
-      rotateRightIcon: React.ReactNode;
-      zoomOutIcon: React.ReactNode;
-      zoomInIcon: React.ReactNode;
-      closeIcon: React.ReactNode;
-    };
-    actions: {
-      flipY: () => void;
-      flipX: () => void;
-      rotateLeft: () => void;
-      rotateRight: () => void;
-      zoomOut: () => void;
-      zoomIn: () => void;
-      close: () => void;
-    };
-    current: number;
-    total: number;
-  }) => React.ReactNode }
+  x: number;
+  y: number;
+  rotate: number;
+  scale: number;
+  flipX: boolean;
+  flipY: boolean;
+}
+```
+
+### TransformAction
+
+```typescript
+type TransformAction =
+  | 'flipY'
+  | 'flipX'
+  | 'rotateLeft'
+  | 'rotateRight'
+  | 'zoomIn'
+  | 'zoomOut'
+  | 'close'
+  | 'switch'
+  | 'wheel'
+  | 'doubleClick'
+  | 'move'
+  | 'dragRebound';
+```
+
+### ToolbarRenderType
+
+```typescript
+{
+  originalNode: React.ReactNode;
+  icons: {
+    flipYIcon: React.ReactNode;
+    flipXIcon: React.ReactNode;
+    rotateLeftIcon: React.ReactNode;
+    rotateRightIcon: React.ReactNode;
+    zoomOutIcon: React.ReactNode;
+    zoomInIcon: React.ReactNode;
+    closeIcon: React.ReactNode;
+  };
+  actions: {
+    flipY: () => void;
+    flipX: () => void;
+    rotateLeft: () => void;
+    rotateRight: () => void;
+    zoomOut: () => void;
+    zoomIn: () => void;
+    close: () => void;
+  };
+  current: number;
+  total: number;
+}
 ```
 
 ## Example

--- a/assets/index.less
+++ b/assets/index.less
@@ -67,6 +67,9 @@
     &-body {
       .box;
       overflow: hidden;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
 
     &.zoom-enter,
@@ -101,14 +104,7 @@
       max-height: 100%;
       pointer-events: auto;
       &-wrapper {
-        .box;
-        &::before {
-          content: '';
-          display: inline-block;
-          height: 50%;
-          width: 1px;
-          margin-right: -1px;
-        }
+        pointer-events: auto;
       }
     }
 

--- a/docs/demo/imageRender.md
+++ b/docs/demo/imageRender.md
@@ -1,0 +1,8 @@
+---
+title: imageRender
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/imageRender.tsx"></code>

--- a/docs/examples/imageRender.tsx
+++ b/docs/examples/imageRender.tsx
@@ -1,0 +1,23 @@
+import Image from 'rc-image';
+import '../../assets/index.less';
+
+export default function imageRender() {
+  return (
+    <div>
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        width={200}
+        preview={{
+          toolbarRender: () => null,
+          imageRender: () => (
+            <video
+              width="100%"
+              controls
+              src="https://mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*uYT7SZwhJnUAAAAAAAAAAAAADgCCAQ"
+            />
+          ),
+        }}
+      />
+    </div>
+  );
+}

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -5,7 +5,8 @@ import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import type { GetContainer } from 'rc-util/lib/PortalWrapper';
 import * as React from 'react';
 import { useState } from 'react';
-import type { PreviewProps, toolbarRenderType } from './Preview';
+import type { TransformType } from './hooks/useImageTransform';
+import type { PreviewProps, ToolbarRenderType } from './Preview';
 import Preview from './Preview';
 import PreviewGroup, { context } from './PreviewGroup';
 
@@ -16,14 +17,18 @@ export interface ImagePreviewType
   > {
   src?: string;
   visible?: boolean;
-  onVisibleChange?: (value: boolean, prevValue: boolean, currentIndex?: number) => void;
+  onVisibleChange?: (value: boolean, prevValue: boolean) => void;
   getContainer?: GetContainer | false;
   mask?: React.ReactNode;
   maskClassName?: string;
   icons?: PreviewProps['icons'];
   scaleStep?: number;
+  imageRender?: (params: {
+    originalNode: React.ReactNode;
+    transform: TransformType;
+  }) => React.ReactNode;
   onTransform?: PreviewProps['onTransform'];
-  toolbarRender?: (params: Omit<toolbarRenderType, 'current' | 'total'>) => React.ReactNode;
+  toolbarRender?: (params: Omit<ToolbarRenderType, 'current' | 'total'>) => React.ReactNode;
 }
 
 let uuid = 0;
@@ -103,6 +108,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
     maskClassName,
     icons,
     scaleStep,
+    imageRender,
     toolbarRender,
     ...dialogProps
   }: ImagePreviewType = typeof preview === 'object' ? preview : {};
@@ -173,8 +179,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
     onClick?.(e);
   };
 
-  const onPreviewClose = (e: React.SyntheticEvent<Element>) => {
-    e.stopPropagation();
+  const onPreviewClose = () => {
     setShowPreview(false);
     if (!isControlled) {
       setMousePosition(null);
@@ -294,6 +299,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
           icons={icons}
           scaleStep={scaleStep}
           rootClassName={rootClassName}
+          imageRender={imageRender}
           imgCommonProps={imgCommonProps}
           toolbarRender={toolbarRender}
           {...dialogProps}

--- a/src/Operations.tsx
+++ b/src/Operations.tsx
@@ -2,7 +2,7 @@ import Portal from '@rc-component/portal';
 import classnames from 'classnames';
 import CSSMotion from 'rc-motion';
 import * as React from 'react';
-import type { PreviewProps } from './Preview';
+import type { PreviewProps, ToolbarRenderType } from './Preview';
 import { context } from './PreviewGroup';
 
 interface OperationsProps
@@ -16,7 +16,6 @@ interface OperationsProps
     | 'icons'
     | 'countRender'
     | 'onClose'
-    | 'toolbarRender'
   > {
   showSwitch: boolean;
   showProgress: boolean;
@@ -30,6 +29,9 @@ interface OperationsProps
   onRotateLeft: () => void;
   onFlipX: () => void;
   onFlipY: () => void;
+  toolbarRender: (
+    params: ToolbarRenderType | Omit<ToolbarRenderType, 'current' | 'total'>,
+  ) => React.ReactNode;
 }
 
 const Operations: React.FC<OperationsProps> = props => {
@@ -166,12 +168,7 @@ const Operations: React.FC<OperationsProps> = props => {
               zoomIn: onZoomIn,
               close: onClose,
             },
-            ...((isPreviewGroup
-              ? {
-                  current: current + 1,
-                  total: count,
-                }
-              : {}) as any),
+            ...(isPreviewGroup ? { current, total: count } : {}),
           })
         : toolbar}
     </>

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -1,20 +1,30 @@
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import * as React from 'react';
 import { useState } from 'react';
+import type { TransformType } from './hooks/useImageTransform';
 import type { ImagePreviewType } from './Image';
-import type { PreviewProps } from './Preview';
+import type { PreviewProps, ToolbarRenderType } from './Preview';
 import Preview from './Preview';
 
 export interface PreviewGroupPreview
-  extends Omit<ImagePreviewType, 'icons' | 'mask' | 'maskClassName' | 'toolbarRender'> {
+  extends Omit<
+    ImagePreviewType,
+    'icons' | 'mask' | 'maskClassName' | 'onVisibleChange' | 'toolbarRender' | 'imageRender'
+  > {
   /**
    * If Preview the show img index
    * @default 0
    */
   current?: number;
   countRender?: (current: number, total: number) => string;
+  toolbarRender?: (params: ToolbarRenderType) => React.ReactNode;
+  imageRender?: (params: {
+    originalNode: React.ReactNode;
+    transform: TransformType;
+    current: number;
+  }) => React.ReactNode;
+  onVisibleChange?: (value: boolean, prevValue: boolean, currentIndex: number) => void;
   onChange?: (current: number, prevCurrent: number) => void;
-  toolbarRender?: PreviewProps['toolbarRender'];
 }
 
 export interface GroupConsumerProps {
@@ -78,6 +88,7 @@ const Group: React.FC<GroupConsumerProps> = ({
     onChange = undefined,
     onTransform = undefined,
     toolbarRender = undefined,
+    imageRender = undefined,
     ...dialogProps
   } = typeof preview === 'object' ? preview : {};
   const [previewData, setPreviewData] = useState<Map<number, PreviewData>>(new Map());
@@ -123,8 +134,7 @@ const Group: React.FC<GroupConsumerProps> = ({
     return unRegister;
   };
 
-  const onPreviewClose = (e: React.SyntheticEvent<Element>) => {
-    e.stopPropagation();
+  const onPreviewClose = () => {
     setShowPreview(false);
     setMousePosition(null);
   };
@@ -168,6 +178,7 @@ const Group: React.FC<GroupConsumerProps> = ({
         countRender={countRender}
         onTransform={onTransform}
         toolbarRender={toolbarRender}
+        imageRender={imageRender}
         {...dialogProps}
       />
     </Provider>

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -844,4 +844,28 @@ describe('Preview', () => {
       action: 'flipY',
     });
   });
+
+  it('imageRender', () => {
+    const { container } = render(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        preview={{
+          imageRender: () => (
+            <video
+              width="100%"
+              controls
+              src="https://mdn.alipayobjects.com/huamei_iwk9zp/afts/file/A*uYT7SZwhJnUAAAAAAAAAAAAADgCCAQ"
+            />
+          ),
+        }}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.rc-image'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(document.querySelector('video')).toBeTruthy();
+  });
 });

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -220,8 +220,8 @@ describe('PreviewGroup', () => {
   it('pass img common props to previewed image', () => {
     const { container } = render(
       <Image.PreviewGroup>
-        <Image src="src1" referrerPolicy='no-referrer' />
-        <Image src="src2" referrerPolicy='origin' />
+        <Image src="src1" referrerPolicy="no-referrer" />
+        <Image src="src2" referrerPolicy="origin" />
       </Image.PreviewGroup>,
     );
 
@@ -230,13 +230,19 @@ describe('PreviewGroup', () => {
       jest.runAllTimers();
     });
 
-    expect(document.querySelector('.rc-image-preview-img')).toHaveAttribute('referrerPolicy', 'no-referrer');
+    expect(document.querySelector('.rc-image-preview-img')).toHaveAttribute(
+      'referrerPolicy',
+      'no-referrer',
+    );
 
     fireEvent.click(document.querySelector('.rc-image-preview-switch-right'));
     act(() => {
       jest.runAllTimers();
     });
 
-    expect(document.querySelector('.rc-image-preview-img')).toHaveAttribute('referrerPolicy', 'origin');
+    expect(document.querySelector('.rc-image-preview-img')).toHaveAttribute(
+      'referrerPolicy',
+      'origin',
+    );
   });
 });


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/27273
https://github.com/ant-design/ant-design/issues/40279

使用 PreviewGroup 的情况下，现在的做法是使用 PreviewGroup 的 imgRender，暴露出 current。看下是否可行
```
<Image.PreviewGroup preview={{ imgRender: (originalNode, current) => ... }}>
   <Image preview={{ imgRender: ... }} />   // 无效
   <Image />
</Image.PreviewGroup>
```