### PR TITLE
feat: showOnlyInPreview

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ export default () => (
 | visible | boolean | - | Whether the preview is open or not |
 | scaleStep | number | 0.5 | The number to which the scale is increased or decreased |
 | forceRender | boolean | - | Force render preview |
+| showOnlyInPreview | boolean | - | only show image in preview |
 | getContainer | string \| HTMLElement \| (() => HTMLElement) \| false | document.body | Return the mount node for preview |
 | imageRender | { originalNode: React.ReactNode, transform: [TransformType](#TransformType) } => React.ReactNode | - | Customize image |
 | toolbarRender | (params: Omit<[ToolbarRenderType](#ToolbarRenderType), 'current' \| 'total'>) => React.ReactNode | - | Customize toolbar |
@@ -116,6 +117,7 @@ export default () => (
 | current | number | - | current index |
 | scaleStep | number | 0.5 | The number to which the scale is increased or decreased |
 | forceRender | boolean | - | Force render preview |
+| showOnlyInPreview | boolean | - | only show image in preview |
 | getContainer | string \| HTMLElement \| (() => HTMLElement) \| false | document.body | Return the mount node for preview |
 | countRender | (current: number, total: number) => string | - | Customize count |
 | imageRender | { originalNode: React.ReactNode, transform: [TransformType](#TransformType), current: number } => React.ReactNode | - | Customize image |

--- a/docs/demo/album.md
+++ b/docs/demo/album.md
@@ -1,0 +1,8 @@
+---
+title: album
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/album.tsx"></code>

--- a/docs/examples/album.tsx
+++ b/docs/examples/album.tsx
@@ -7,8 +7,7 @@ export default function PreviewGroup() {
       <Image.PreviewGroup>
         <Image src={require('./images/1.jpeg')} />
         <Image preview={{ showOnlyInPreview: true }} src={require('./images/2.jpeg')} />
-        <Image preview={{ showOnlyInPreview: true }} src={require('./images/3.jpeg')} />
-        <Image preview={{ showOnlyInPreview: true }} src="error" alt="error" />
+        <Image src={require('./images/3.jpeg')} />
         <Image preview={{ showOnlyInPreview: true }} src={require('./images/1.jpeg')} />
       </Image.PreviewGroup>
     </div>

--- a/docs/examples/album.tsx
+++ b/docs/examples/album.tsx
@@ -1,0 +1,16 @@
+import Image from 'rc-image';
+import '../../assets/index.less';
+
+export default function PreviewGroup() {
+  return (
+    <div>
+      <Image.PreviewGroup>
+        <Image src={require('./images/1.jpeg')} />
+        <Image preview={{ showOnlyInPreview: true }} src={require('./images/2.jpeg')} />
+        <Image preview={{ showOnlyInPreview: true }} src={require('./images/3.jpeg')} />
+        <Image preview={{ showOnlyInPreview: true }} src="error" alt="error" />
+        <Image preview={{ showOnlyInPreview: true }} src={require('./images/1.jpeg')} />
+      </Image.PreviewGroup>
+    </div>
+  );
+}

--- a/docs/examples/previewgroup.tsx
+++ b/docs/examples/previewgroup.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable global-require */
-import * as React from 'react';
 import Image from 'rc-image';
 import '../../assets/index.less';
 
@@ -9,7 +7,8 @@ export default function PreviewGroup() {
       <Image.PreviewGroup
         preview={{
           countRender: (current, total) => `第${current}张 / 总共${total}张`,
-          onChange: (current, prev) => console.log(`当前第${current}张，上一次第${prev === undefined ? '-' : prev}张`)
+          onChange: (current, prev) =>
+            console.log(`当前第${current}张，上一次第${prev === undefined ? '-' : prev}张`),
         }}
       >
         <Image wrapperStyle={{ marginRight: 24, width: 200 }} src={require('./images/1.jpeg')} />

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -19,6 +19,7 @@ export interface ImagePreviewType
   visible?: boolean;
   onVisibleChange?: (value: boolean, prevValue: boolean) => void;
   getContainer?: GetContainer | false;
+  showOnlyInPreview?: boolean;
   mask?: React.ReactNode;
   maskClassName?: string;
   icons?: PreviewProps['icons'];
@@ -104,6 +105,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
     visible: previewVisible = undefined,
     onVisibleChange: onPreviewVisibleChange = onInitialPreviewClose,
     getContainer: getPreviewContainer = undefined,
+    showOnlyInPreview,
     mask: previewMask,
     maskClassName,
     icons,
@@ -123,6 +125,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
   const isError = status === 'error';
   const {
     isPreviewGroup,
+    showOnlyInPreview: previewGroupOnly,
     setCurrent,
     setShowPreview: setGroupShowPreview,
     setMousePosition: setGroupMousePosition,
@@ -236,56 +239,61 @@ const ImageInternal: CompoundedComponent<ImageProps> = ({
 
   const mergedSrc = isError && fallback ? fallback : src;
 
+  const mergedOnly =
+    isPreviewGroup && showOnlyInPreview === undefined ? previewGroupOnly : showOnlyInPreview;
+
   return (
     <>
-      <div
-        {...otherProps}
-        className={wrapperClass}
-        onClick={canPreview ? onPreview : onClick}
-        style={{
-          width,
-          height,
-          ...wrapperStyle,
-        }}
-      >
-        <img
-          {...imgCommonProps}
-          className={cn(
-            `${prefixCls}-img`,
-            {
-              [`${prefixCls}-img-placeholder`]: placeholder === true,
-            },
-            className,
-          )}
+      {!mergedOnly && (
+        <div
+          {...otherProps}
+          className={wrapperClass}
+          onClick={canPreview ? onPreview : onClick}
           style={{
+            width,
             height,
-            ...style,
+            ...wrapperStyle,
           }}
-          ref={getImgRef}
-          {...(isError && fallback ? { src: fallback } : { onLoad, src: imgSrc })}
-          width={width}
-          height={height}
-          onError={onError}
-        />
-
-        {status === 'loading' && (
-          <div aria-hidden="true" className={`${prefixCls}-placeholder`}>
-            {placeholder}
-          </div>
-        )}
-
-        {/* Preview Click Mask */}
-        {previewMask && canPreview && (
-          <div
-            className={cn(`${prefixCls}-mask`, maskClassName)}
+        >
+          <img
+            {...imgCommonProps}
+            className={cn(
+              `${prefixCls}-img`,
+              {
+                [`${prefixCls}-img-placeholder`]: placeholder === true,
+              },
+              className,
+            )}
             style={{
-              display: style?.display === 'none' ? 'none' : undefined,
+              height,
+              ...style,
             }}
-          >
-            {previewMask}
-          </div>
-        )}
-      </div>
+            ref={getImgRef}
+            {...(isError && fallback ? { src: fallback } : { onLoad, src: imgSrc })}
+            width={width}
+            height={height}
+            onError={onError}
+          />
+
+          {status === 'loading' && (
+            <div aria-hidden="true" className={`${prefixCls}-placeholder`}>
+              {placeholder}
+            </div>
+          )}
+
+          {/* Preview Click Mask */}
+          {previewMask && canPreview && (
+            <div
+              className={cn(`${prefixCls}-mask`, maskClassName)}
+              style={{
+                display: style?.display === 'none' ? 'none' : undefined,
+              }}
+            >
+              {previewMask}
+            </div>
+          )}
+        </div>
+      )}
       {!isPreviewGroup && canPreview && (
         <Preview
           aria-hidden={!isShowPreview}

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -42,6 +42,7 @@ interface PreviewData {
 
 export interface GroupConsumerValue extends GroupConsumerProps {
   isPreviewGroup?: boolean;
+  showOnlyInPreview?: boolean;
   previewData: Map<number, PreviewData>;
   setPreviewData: React.Dispatch<React.SetStateAction<Map<number, PreviewData>>>;
   current: number;
@@ -82,6 +83,7 @@ const Group: React.FC<GroupConsumerProps> = ({
   const {
     visible: previewVisible = undefined,
     onVisibleChange: onPreviewVisibleChange = undefined,
+    showOnlyInPreview = undefined,
     getContainer = undefined,
     current: currentIndex = 0,
     countRender = undefined,
@@ -155,6 +157,7 @@ const Group: React.FC<GroupConsumerProps> = ({
     <Provider
       value={{
         isPreviewGroup: true,
+        showOnlyInPreview,
         previewData: canPreviewData,
         setPreviewData,
         current,

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -92,6 +92,21 @@ describe('Preview', () => {
     onPreviewCloseMock.mockRestore();
   });
 
+  it('showOnlyInPreview', () => {
+    const { container } = render(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        preview={{
+          showOnlyInPreview: true,
+          visible: true,
+        }}
+      />,
+    );
+
+    expect(container.querySelector('.rc-image')).toBeFalsy();
+    expect(document.querySelector('.rc-image-preview')).toBeTruthy();
+  });
+
   it('Unmount', () => {
     const { container, unmount } = render(
       <Image src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png" />,

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -245,4 +245,28 @@ describe('PreviewGroup', () => {
       'origin',
     );
   });
+
+  it('album mode', () => {
+    const { container } = render(
+      <Image.PreviewGroup>
+        <Image src="src1" />
+        <Image preview={{ showOnlyInPreview: true }} src="src2" />
+        <Image preview={{ showOnlyInPreview: true }} src="src3" />
+      </Image.PreviewGroup>,
+    );
+
+    expect(container.querySelectorAll('.rc-image')).toHaveLength(1);
+
+    fireEvent.click(container.querySelector('.rc-image'));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(document.querySelector('.rc-image-preview-img')).toHaveAttribute('src', 'src1');
+
+    fireEvent.click(document.querySelector('.rc-image-preview-switch-right'));
+    expect(document.querySelector('.rc-image-preview-img')).toHaveAttribute('src', 'src2');
+
+    fireEvent.click(document.querySelector('.rc-image-preview-switch-right'));
+    expect(document.querySelector('.rc-image-preview-img')).toHaveAttribute('src', 'src3');
+  });
 });


### PR DESCRIPTION
组件自身实现相册模式
代替 https://ant.design/components/image-cn#components-image-demo-preview-group-visible

隐藏 dom，用户自己用受控 visible 展示预览
```
<Image preview={{ only: true }} />

or

<Image.PreviewGroup preview={{ only: true }}>
  ....
</Image.PreviewGroup>
```

相册模式，用户自行决定外面显示哪个图片，只要这个图片不设置 only 即可。
```
<Image.PreviewGroup>
  <Image />
  <Image preview={{ only: true }} />
  <Image preview={{ only: true }} />
</Image.PreviewGroup>
```