### PR TITLE
fix: optimize preview setting index

### DIFF
--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -62,7 +62,7 @@ interface CompoundedComponent<P> extends React.FC<P> {
 
 type ImageStatus = 'normal' | 'error' | 'loading';
 
-const COMMON_PROPS: (keyof ImageElementProps)[] = [
+export const COMMON_PROPS: (keyof Omit<ImageElementProps, 'src'>)[] = [
   'crossOrigin',
   'decoding',
   'draggable',

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -90,8 +90,8 @@ const Group: React.FC<GroupConsumerProps> = ({
 
       setShowPreview(true);
       setMousePosition({ x: mouseX, y: mouseY });
-      setCurrent(index);
-      setKeepOpenIndex(index >= 0);
+      setCurrent(index < 0 ? 0 : index);
+      setKeepOpenIndex(true);
     },
     [mergedItems],
   );
@@ -118,7 +118,6 @@ const Group: React.FC<GroupConsumerProps> = ({
     setShowPreview(false);
     setMousePosition(null);
   };
-
 
   // ========================= Context ==========================
   const previewGroupContext = React.useMemo(

--- a/src/hooks/usePreviewItems.ts
+++ b/src/hooks/usePreviewItems.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { COMMON_PROPS } from '..';
+import { COMMON_PROPS } from '../Image';
 import type {
   ImageElementProps,
   InternalItem,

--- a/src/hooks/usePreviewItems.ts
+++ b/src/hooks/usePreviewItems.ts
@@ -42,9 +42,9 @@ export default function usePreviewItems(
           return { data: { src: item } };
         }
         const data: ImageElementProps = {};
-        Object.keys(items).forEach(key => {
+        Object.keys(item).forEach(key => {
           if (['src', ...COMMON_PROPS].includes(key)) {
-            data[key] = items[key];
+            data[key] = item[key];
           }
         });
         return { data };

--- a/src/hooks/usePreviewItems.ts
+++ b/src/hooks/usePreviewItems.ts
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import type { InternalItem, PreviewImageElementProps, RegisterImage } from '../interface';
+import { COMMON_PROPS } from '..';
+import type {
+  ImageElementProps,
+  InternalItem,
+  PreviewImageElementProps,
+  RegisterImage,
+} from '../interface';
 import type { GroupConsumerProps } from '../PreviewGroup';
 
 export type Items = Omit<InternalItem, 'canPreview'>[];
@@ -31,9 +37,18 @@ export default function usePreviewItems(
   // items
   const mergedItems = React.useMemo<Items>(() => {
     if (items) {
-      return items.map(item =>
-        typeof item === 'string' ? { data: { src: item } } : { data: item },
-      );
+      return items.map(item => {
+        if (typeof item === 'string') {
+          return { data: { src: item } };
+        }
+        const data: ImageElementProps = {};
+        Object.keys(items).forEach(key => {
+          if (['src', ...COMMON_PROPS].includes(key)) {
+            data[key] = items[key];
+          }
+        });
+        return { data };
+      });
     }
 
     return Object.keys(images).reduce((total: Items, id) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "moduleResolution": "node",
     "baseUrl": "./",
-    "jsx": "react",
+    "jsx": "preserve",
     "declaration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
1、优化打开预览时 index 判断，可减少渲染
2、只 pick items 的 ts 定义的那部分属性，保持一致。