### PR TITLE
chore: adjust tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "moduleResolution": "node",
     "baseUrl": "./",
-    "jsx": "preserve",
+    "jsx": "react",
     "declaration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
fix https://github.com/react-component/image/pull/258/files#r1233237066

`prettier-plugin-sort-imports` 会移除非必要引入，作为组件库会 break 掉使用。例如创建一个 `tmp.tsx` 写以下代码：

```tsx
import React from 'react';

export default () => <></>;
```

当 tsconfig 设置 `"jsx": "preserve"` 后，会被 prettier 掉成：

```tsx
export default () => <></>;
```

编译后代码为：

```js
export default (function () {
  return /*#__PURE__*/React.createElement(React.Fragment, null);
});
```

 导致使用该库的用户报错 React 未定义，`tsconfig` 中设置 `"jsx": "react"` 即可。