### PR TITLE
refactor: solve image circular dependency issue

### DIFF
--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -12,6 +12,7 @@ import type { ImageElementProps } from './interface';
 import type { PreviewProps, ToolbarRenderInfoType } from './Preview';
 import Preview from './Preview';
 import PreviewGroup from './PreviewGroup';
+import { COMMON_PROPS as CommonProps } from './common';
 
 export interface ImagePreviewType
   extends Omit<
@@ -65,17 +66,7 @@ interface CompoundedComponent<P> extends React.FC<P> {
 
 type ImageStatus = 'normal' | 'error' | 'loading';
 
-export const COMMON_PROPS: (keyof Omit<ImageElementProps, 'src'>)[] = [
-  'crossOrigin',
-  'decoding',
-  'draggable',
-  'loading',
-  'referrerPolicy',
-  'sizes',
-  'srcSet',
-  'useMap',
-  'alt',
-];
+export const COMMON_PROPS = CommonProps;
 
 function isImageValid(src) {
   return new Promise(resolve => {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,13 @@
+import type { ImageElementProps } from './interface';
+
+export const COMMON_PROPS: (keyof Omit<ImageElementProps, 'src'>)[] = [
+  'crossOrigin',
+  'decoding',
+  'draggable',
+  'loading',
+  'referrerPolicy',
+  'sizes',
+  'srcSet',
+  'useMap',
+  'alt',
+];

--- a/src/hooks/usePreviewItems.ts
+++ b/src/hooks/usePreviewItems.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { COMMON_PROPS } from '../Image';
+import { COMMON_PROPS } from '../common';
 import type {
   ImageElementProps,
   InternalItem,


### PR DESCRIPTION
https://github.com/ant-design/ant-design/pull/42750

- (undefined) Circular dependency detected:
node_modules/rc-image/es/Image.js -> node_modules/rc-image/es/PreviewGroup.js -> node_modules/rc-image/es/hooks/usePreviewItems.js -> node_modules/rc-image/es/Image.js
- (undefined) Circular dependency detected:
node_modules/rc-image/es/PreviewGroup.js -> node_modules/rc-image/es/hooks/usePreviewItems.js -> node_modules/rc-image/es/Image.js -> node_modules/rc-image/es/PreviewGroup.js
- (undefined) Circular dependency detected:
node_modules/rc-image/es/hooks/usePreviewItems.js -> node_modules/rc-image/es/Image.js -> node_modules/rc-image/es/PreviewGroup.js -> node_modules/rc-image/es/hooks/usePreviewItems.js