### PR TITLE
fix: should be closed when press esc after click portal

### DIFF
--- a/src/Operations.tsx
+++ b/src/Operations.tsx
@@ -1,6 +1,7 @@
 import Portal from '@rc-component/portal';
 import classnames from 'classnames';
 import CSSMotion from 'rc-motion';
+import KeyCode from 'rc-util/lib/KeyCode';
 import * as React from 'react';
 import { useContext } from 'react';
 import { PreviewGroupContext } from './context';
@@ -74,6 +75,22 @@ const Operations: React.FC<OperationsProps> = props => {
   const groupContext = useContext(PreviewGroupContext);
   const { rotateLeft, rotateRight, zoomIn, zoomOut, close, left, right, flipX, flipY } = icons;
   const toolClassName = `${prefixCls}-operations-operation`;
+
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.keyCode === KeyCode.ESC) {
+        onClose();
+      }
+    };
+
+    if (visible) {
+      window.addEventListener('keydown', onKeyDown);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [visible]);
 
   const tools = [
     {

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -887,6 +887,7 @@ describe('Preview', () => {
     fireEvent.keyDown(window, { key: 'Escape', keyCode: 27 });
 
     expect(onVisibleChange).toBeCalledWith(false, true);
+    expect(onVisibleChange).toBeCalledTimes(2);
 
     onVisibleChange.mockRestore();
   });

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -861,4 +861,33 @@ describe('Preview', () => {
 
     expect(document.querySelector('video')).toBeTruthy();
   });
+
+  it('should be closed when press esc after click portal', () => {
+    const onVisibleChange = jest.fn();
+    const { container } = render(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        preview={{
+          onVisibleChange,
+        }}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.rc-image'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(document.querySelector('.rc-image-preview')).toBeTruthy();
+
+    expect(onVisibleChange).toBeCalledWith(true, false);
+
+    fireEvent.click(document.querySelector('.rc-image-preview-operations'));
+
+    fireEvent.keyDown(window, { key: 'Escape', keyCode: 27 });
+
+    expect(onVisibleChange).toBeCalledWith(false, true);
+
+    onVisibleChange.mockRestore();
+  });
 });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/43912

没点击 Portal 时，按下 esc 有效，因为是走的 rc-dialog 的 onClose（绑在 div 上），点击 Portal 后就无效了。于是给 Portal 单独绑定 esc 