### PR TITLE
Change state to 'normal' if 'src' is valid

### DIFF
--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -20,7 +20,9 @@ export default function useStatus({
   // https://github.com/react-component/image/pull/187
   useEffect(() => {
     isImageValid(src).then(isValid => {
-      if (!isValid) {
+      if (isValid) {
+        setStatus('normal');
+      } else {
         setStatus('error');
       }
     });
@@ -49,7 +51,7 @@ export default function useStatus({
     }
   };
 
-  const srcAndOnload = isError && fallback ? { onLoad, src: fallback } : { onLoad, src };
+  const srcAndOnload = isError && fallback ? { src: fallback } : { onLoad, src };
 
   return [getImgRef, srcAndOnload, status] as const;
 }

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -49,7 +49,7 @@ export default function useStatus({
     }
   };
 
-  const srcAndOnload = isError && fallback ? { src: fallback } : { onLoad, src };
+  const srcAndOnload = isError && fallback ? { onLoad, src: fallback } : { onLoad, src };
 
   return [getImgRef, srcAndOnload, status] as const;
 }

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,5 +1,5 @@
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
 import Image from '../src';
 
 describe('Basic', () => {
@@ -86,5 +86,32 @@ describe('Basic', () => {
     );
     const maskElement = container.querySelector('.rc-image-mask');
     expect(maskElement).toHaveStyle({ display: 'none' });
+  });
+
+  it('Valid image after few switching of src', async () => {
+    const valid1 = 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png';
+    const valid2 =
+      'https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*NZuwQp_vcIQAAAAAAAAAAABkARQnAQ';
+    const fallback =
+      'https://gw.alipayobjects.com/zos/antfincdn/LlvErxo8H9/photo-1503185912284-5271ff81b9a8.webp';
+
+    const images = ['error', valid1, 'error', valid2];
+
+    const TestCase = () => {
+      const [idx, setIdx] = React.useState(0);
+
+      React.useEffect(() => {
+        if (idx < images.length - 1) {
+          setIdx(idx + 1);
+        }
+      }, [idx]);
+
+      return <Image src={images[idx]} fallback={fallback} />;
+    };
+
+    const { container } = render(<TestCase />);
+    const maskElement = container.querySelector('.rc-image-img');
+
+    expect(maskElement).toHaveAttribute('src', valid2);
   });
 });


### PR DESCRIPTION
Possible fix for https://github.com/react-component/image/issues/277

## Explaining

We are not providing `onLoad` handler if `status=error` and there is a `fallback` image. So if `src` was changed to "valid" There is no way `status` can be changed to "normal". 

Possible decision is to `change` status to `normal` when `src` checked and became `valid`