### PR TITLE
fix:修复预览图片默认被设置成了缩略图的尺寸

### DIFF
--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -240,8 +240,6 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
           mousePosition={mousePosition}
           src={src}
           alt={alt}
-          width={width}
-          height={height}
           fallback={fallback}
           getContainer={getPreviewContainer}
           icons={icons}


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/49235