### PR TITLE
test: stable rootClassName

### DIFF
--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -727,6 +727,50 @@ describe('Preview', () => {
     expect(document.querySelector('.rc-image-preview.custom-className')).toBeTruthy();
   });
 
+  it('rootClassName on both side but classNames.root on single side', () => {
+    const src = 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png';
+    render(
+      <Image
+        src={src}
+        rootClassName="both"
+        classNames={{ root: 'image-root' }}
+        styles={{
+          root: {
+            color: 'red',
+          },
+        }}
+        preview={{
+          open: true,
+          classNames: {
+            root: 'preview-root',
+          },
+          styles: {
+            root: {
+              background: 'green',
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(document.querySelectorAll('.both')).toHaveLength(2);
+    expect(document.querySelectorAll('.rc-image.image-root')).toHaveLength(1);
+    expect(document.querySelectorAll('.rc-image-preview.preview-root')).toHaveLength(1);
+
+    expect(document.querySelector('.rc-image.image-root')).toHaveStyle({
+      color: 'red',
+    });
+    expect(document.querySelector('.rc-image.image-root')).not.toHaveStyle({
+      background: 'green',
+    });
+    expect(document.querySelector('.rc-image-preview.preview-root')).toHaveStyle({
+      background: 'green',
+    });
+    expect(document.querySelector('.rc-image-preview.preview-root')).not.toHaveStyle({
+      color: 'red',
+    });
+  });
+
   it('if async src set should be correct', () => {
     const src =
       'https://gw.alipayobjects.com/mdn/rms_08e378/afts/img/A*P0S-QIRUbsUAAAAAAAAAAABkARQnAQ';


### PR DESCRIPTION
加个测试固化一下 rootClassName 的行为

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
	- 新增测试用例，验证图像和预览组件在同时应用通用和自定义样式时，能正确展示预期的视觉效果（如图像的红色效果与预览的绿色背景）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->