### PR TITLE
refactor: Move semantic props

### DIFF
--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -259,10 +259,10 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
           imageInfo={{ width, height }}
           fallback={fallback}
           imgCommonProps={imgCommonProps}
+          {...restProps}
           classNames={classNames?.popup}
           styles={styles?.popup}
           rootClassName={classnames(previewRootClassName, rootClassName)}
-          {...restProps}
         />
       )}
     </>

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -2,11 +2,7 @@ import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
 import classnames from 'classnames';
 import * as React from 'react';
 import { useContext, useMemo, useState } from 'react';
-import type {
-  InternalPreviewConfig,
-  InternalPreviewSemanticName,
-  ToolbarRenderInfoType,
-} from './Preview';
+import type { InternalPreviewConfig, PreviewSemanticName, ToolbarRenderInfoType } from './Preview';
 import Preview from './Preview';
 import PreviewGroup from './PreviewGroup';
 import { COMMON_PROPS } from './common';
@@ -25,8 +21,6 @@ export interface ImgInfo {
 
 export interface PreviewConfig extends Omit<InternalPreviewConfig, 'countRender'> {
   cover?: React.ReactNode;
-  classNames?: Partial<Record<PreviewSemanticName, string>>;
-  styles?: Partial<Record<PreviewSemanticName, React.CSSProperties>>;
 
   // Similar to InternalPreviewConfig but not have `current`
   imageRender?: (
@@ -43,9 +37,7 @@ export interface PreviewConfig extends Omit<InternalPreviewConfig, 'countRender'
   onOpenChange?: (open: boolean) => void;
 }
 
-export type SemanticName = 'root' | 'image';
-
-export type PreviewSemanticName = InternalPreviewSemanticName | 'cover';
+export type SemanticName = 'root' | 'image' | 'cover';
 
 export interface ImageProps
   extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onClick'> {
@@ -55,8 +47,16 @@ export interface ImageProps
 
   // Styles
   rootClassName?: string;
-  classNames?: Partial<Record<SemanticName, string>>;
-  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
+  classNames?: Partial<
+    Record<SemanticName, string> & {
+      popup?: Partial<Record<PreviewSemanticName, string>>;
+    }
+  >;
+  styles?: Partial<
+    Record<SemanticName, React.CSSProperties> & {
+      popup?: Partial<Record<PreviewSemanticName, React.CSSProperties>>;
+    }
+  >;
 
   // Image
   src?: string;
@@ -117,8 +117,6 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
     open: previewOpen,
     onOpenChange: onPreviewOpenChange,
     cover,
-    classNames: previewClassNames = {},
-    styles: previewStyles = {},
     rootClassName: previewRootClassName,
     ...restProps
   }: PreviewConfig = preview && typeof preview === 'object' ? preview : {};
@@ -239,10 +237,10 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
         {/* Preview Click Mask */}
         {cover !== false && canPreview && (
           <div
-            className={classnames(`${prefixCls}-cover`, previewClassNames.cover)}
+            className={classnames(`${prefixCls}-cover`, classNames.cover)}
             style={{
               display: style?.display === 'none' ? 'none' : undefined,
-              ...previewStyles.cover,
+              ...styles.cover,
             }}
           >
             {cover}
@@ -261,8 +259,8 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
           imageInfo={{ width, height }}
           fallback={fallback}
           imgCommonProps={imgCommonProps}
-          classNames={previewClassNames}
-          styles={previewStyles}
+          classNames={classNames?.popup}
+          styles={styles?.popup}
           rootClassName={classnames(previewRootClassName, rootClassName)}
           {...restProps}
         />

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -19,7 +19,7 @@ import PrevNext from './PrevNext';
 
 // Note: if you want to add `action`,
 // pls contact @zombieJ or @thinkasany first.
-export type InternalPreviewSemanticName = 'root' | 'mask' | 'body' | FooterSemanticName;
+export type PreviewSemanticName = 'root' | 'mask' | 'body' | FooterSemanticName;
 
 export interface OperationIcons {
   rotateLeft?: React.ReactNode;
@@ -71,8 +71,6 @@ export interface InternalPreviewConfig {
   // Semantic
   /** Better to use `classNames.root` instead */
   rootClassName?: string;
-  classNames?: Partial<Record<InternalPreviewSemanticName, string>>;
-  styles?: Partial<Record<InternalPreviewSemanticName, React.CSSProperties>>;
 
   // Image
   src?: string;
@@ -112,6 +110,9 @@ export interface InternalPreviewConfig {
 export interface PreviewProps extends InternalPreviewConfig {
   // Misc
   prefixCls: string;
+
+  classNames?: Partial<Record<PreviewSemanticName, string>>;
+  styles?: Partial<Record<PreviewSemanticName, React.CSSProperties>>;
 
   // Origin image Info
   imageInfo?: {

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -2,7 +2,7 @@ import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
 import * as React from 'react';
 import { useState } from 'react';
 import type { ImgInfo } from './Image';
-import type { InternalPreviewConfig, PreviewProps } from './Preview';
+import type { InternalPreviewConfig, PreviewProps, PreviewSemanticName } from './Preview';
 import Preview from './Preview';
 import { PreviewGroupContext } from './context';
 import type { TransformType } from './hooks/useImageTransform';
@@ -20,8 +20,16 @@ export interface GroupPreviewConfig extends InternalPreviewConfig {
   onChange?: (current: number, prevCurrent: number) => void;
 }
 
-export interface GroupConsumerProps {
+export interface PreviewGroupProps {
   previewPrefixCls?: string;
+  classNames?: {
+    popup?: Partial<Record<PreviewSemanticName, string>>;
+  };
+
+  styles?: {
+    popup?: Partial<Record<PreviewSemanticName, React.CSSProperties>>;
+  };
+
   icons?: PreviewProps['icons'];
   items?: (string | ImageElementProps)[];
   fallback?: string;
@@ -29,8 +37,10 @@ export interface GroupConsumerProps {
   children?: React.ReactNode;
 }
 
-const Group: React.FC<GroupConsumerProps> = ({
+const Group: React.FC<PreviewGroupProps> = ({
   previewPrefixCls = 'rc-image-preview',
+  classNames,
+  styles,
   children,
   icons = {},
   items,
@@ -131,6 +141,8 @@ const Group: React.FC<GroupConsumerProps> = ({
         current={current}
         count={mergedItems.length}
         onChange={onInternalChange}
+        classNames={classNames?.popup}
+        styles={styles?.popup}
         {...restProps}
       />
     </PreviewGroupContext.Provider>

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -141,9 +141,9 @@ const Group: React.FC<PreviewGroupProps> = ({
         current={current}
         count={mergedItems.length}
         onChange={onInternalChange}
+        {...restProps}
         classNames={classNames?.popup}
         styles={styles?.popup}
-        {...restProps}
       />
     </PreviewGroupContext.Provider>
   );

--- a/src/hooks/usePreviewItems.ts
+++ b/src/hooks/usePreviewItems.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { GroupConsumerProps } from '../PreviewGroup';
+import type { PreviewGroupProps } from '../PreviewGroup';
 import { COMMON_PROPS } from '../common';
 import type {
   ImageElementProps,
@@ -14,7 +14,7 @@ export type Items = Omit<InternalItem, 'canPreview'>[];
  * Merge props provided `items` or context collected images
  */
 export default function usePreviewItems(
-  items?: GroupConsumerProps['items'],
+  items?: PreviewGroupProps['items'],
 ): [items: Items, registerImage: RegisterImage, fromItems: boolean] {
   // Context collection image data
   const [images, setImages] = React.useState<Record<number, PreviewImageElementProps>>({});

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -609,11 +609,11 @@ describe('Preview', () => {
     render(
       <Image
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        classNames={{
+          cover: 'bamboo',
+        }}
         preview={{
           cover: 'Bamboo Is Light',
-          classNames: {
-            cover: 'bamboo',
-          },
         }}
       />,
     );
@@ -1073,26 +1073,30 @@ describe('Preview', () => {
   it('support classnames and styles', () => {
     const customClassnames = {
       cover: 'custom-cover',
-      mask: 'custom-mask',
-      actions: 'custom-actions',
-      root: 'custom-root',
+      popup: {
+        mask: 'custom-mask',
+        actions: 'custom-actions',
+        root: 'custom-root',
+      },
     };
     const customStyles = {
       cover: { color: 'red' },
-      mask: { color: 'red' },
-      actions: { backgroundColor: 'blue' },
-      root: { border: '1px solid green' },
+      popup: {
+        mask: { color: 'red' },
+        actions: { backgroundColor: 'blue' },
+        root: { border: '1px solid green' },
+      },
     };
     const { baseElement } = render(
       <Image
         src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
         preview={{
-          styles: customStyles,
-          classNames: customClassnames,
           cover: 'Bamboo Is Light',
           zIndex: 9999,
           open: true,
         }}
+        classNames={customClassnames}
+        styles={customStyles}
       />,
     );
 
@@ -1101,11 +1105,11 @@ describe('Preview', () => {
     const actions = baseElement.querySelector('.rc-image-preview-actions');
     expect(cover).toHaveClass(customClassnames.cover);
     expect(cover).toHaveStyle(customStyles.cover);
-    expect(mask).toHaveClass(customClassnames.mask);
-    expect(mask).toHaveStyle(customStyles.mask);
-    expect(actions).toHaveClass(customClassnames.actions);
-    expect(actions).toHaveStyle(customStyles.actions);
-    expect(baseElement.querySelector('.rc-image-preview')).toHaveClass(customClassnames.root);
-    expect(baseElement.querySelector('.rc-image-preview')).toHaveStyle(customStyles.root);
+    expect(mask).toHaveClass(customClassnames.popup.mask);
+    expect(mask).toHaveStyle(customStyles.popup.mask);
+    expect(actions).toHaveClass(customClassnames.popup.actions);
+    expect(actions).toHaveStyle(customStyles.popup.actions);
+    expect(baseElement.querySelector('.rc-image-preview')).toHaveClass(customClassnames.popup.root);
+    expect(baseElement.querySelector('.rc-image-preview')).toHaveStyle(customStyles.popup.root);
   });
 });

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -733,22 +733,24 @@ describe('Preview', () => {
       <Image
         src={src}
         rootClassName="both"
-        classNames={{ root: 'image-root' }}
+        classNames={{
+          root: 'image-root',
+          popup: {
+            root: 'preview-root',
+          },
+        }}
         styles={{
           root: {
             color: 'red',
           },
-        }}
-        preview={{
-          open: true,
-          classNames: {
-            root: 'preview-root',
-          },
-          styles: {
+          popup: {
             root: {
               background: 'green',
             },
           },
+        }}
+        preview={{
+          open: true,
         }}
       />,
     );


### PR DESCRIPTION
### 改动

* `preview.classNames` -> `classNames.popup`
* `preview.styles` -> `styles.popup`

### 为何这么改

和 @thinkasany 聊下来 `classNames` 为唯一入口，子级组件都从 `classNames` 中走。以统一复杂结构的逻辑。例如 Transfer 组件使用了 Dropdown、Pagination、Input.Search 组件，但是本身并没有透出对应的 API 进行配置子组件的能力。如果是散装配置则需要每个都提供一个仅能配置 `classNames` 和 `styles` 的一级入口，会非常怪异。统一收口后，使用复合子组件的场景不需要额外打孔即可支持。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 增强了图像预览的样式配置功能，现在可以对弹出效果单独定制类名和样式，为用户带来更灵活的视觉自定义体验。

- **重构**
	- 统一并简化了预览组件中样式和类名的命名体系，优化了配置结构，使整体设置更直观高效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->