### PR TITLE
fix: progressNode position in rtl mode

### DIFF
--- a/src/Preview/Footer.tsx
+++ b/src/Preview/Footer.tsx
@@ -86,7 +86,7 @@ export default function Footer(props: FooterProps) {
   // >>>>> Progress
   const progressNode = showProgress && (
     <div className={`${prefixCls}-progress`}>
-      {countRender ? countRender(current + 1, count) : `${current + 1} / ${count}`}
+      <bdi>{countRender ? countRender(current + 1, count) : `${current + 1} / ${count}`}</bdi>
     </div>
   );
 

--- a/src/Preview/Footer.tsx
+++ b/src/Preview/Footer.tsx
@@ -86,7 +86,7 @@ export default function Footer(props: FooterProps) {
   // >>>>> Progress
   const progressNode = showProgress && (
     <div className={`${prefixCls}-progress`}>
-      <bdi>{countRender ? countRender(current + 1, count) : `${current + 1} / ${count}`}</bdi>
+      {countRender ? countRender(current + 1, count) : <bdi>{`${current + 1} / ${count}`}</bdi>}
     </div>
   );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 优化了底部进度显示的排版表现，默认情况下进度文本现在会被包裹在<bdi>标签中，以提升多语言和文本方向兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->