### PR TITLE
feat: support custom cover placement

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -28,11 +28,52 @@
   &-img {
     width: 100%;
     height: auto;
+    overflow: hidden;
     &-placeholder {
       background-color: @background-color;
       background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjhweCIgaGVpZ2h0PSIyMnB4IiB2aWV3Qm94PSIwIDAgMjggMjIiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDU1LjIgKDc4MTgxKSAtIGh0dHBzOi8vc2tldGNoYXBwLmNvbSAtLT4KICAgIDx0aXRsZT5pbWFnZS1maWxs5aSH5Lu9PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGcgaWQ9Iuafpeeci+WbvueJh+S8mOWMljQuMCIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IuWKoOi9veWbvueJhyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTU3Mi4wMDAwMDAsIC01MDYuMDAwMDAwKSI+CiAgICAgICAgICAgIDxnIGlkPSJpbWFnZS1maWxs5aSH5Lu9IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg1NzAuMDAwMDAwLCA1MDEuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICA8cmVjdCBpZD0iUmVjdGFuZ2xlIiBmaWxsPSIjMDAwMDAwIiBvcGFjaXR5PSIwIiB4PSIwIiB5PSIwIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiPjwvcmVjdD4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0yOSw1IEwzLDUgQzIuNDQ2ODc1LDUgMiw1LjQ0Njg3NSAyLDYgTDIsMjYgQzIsMjYuNTUzMTI1IDIuNDQ2ODc1LDI3IDMsMjcgTDI5LDI3IEMyOS41NTMxMjUsMjcgMzAsMjYuNTUzMTI1IDMwLDI2IEwzMCw2IEMzMCw1LjQ0Njg3NSAyOS41NTMxMjUsNSAyOSw1IFogTTEwLjU2MjUsOS41IEMxMS42NjU2MjUsOS41IDEyLjU2MjUsMTAuMzk2ODc1IDEyLjU2MjUsMTEuNSBDMTIuNTYyNSwxMi42MDMxMjUgMTEuNjY1NjI1LDEzLjUgMTAuNTYyNSwxMy41IEM5LjQ1OTM3NSwxMy41IDguNTYyNSwxMi42MDMxMjUgOC41NjI1LDExLjUgQzguNTYyNSwxMC4zOTY4NzUgOS40NTkzNzUsOS41IDEwLjU2MjUsOS41IFogTTI2LjYyMTg3NSwyMy4xNTkzNzUgQzI2LjU3ODEyNSwyMy4xOTY4NzUgMjYuNTE4NzUsMjMuMjE4NzUgMjYuNDU5Mzc1LDIzLjIxODc1IEw1LjUzNzUsMjMuMjE4NzUgQzUuNCwyMy4yMTg3NSA1LjI4NzUsMjMuMTA2MjUgNS4yODc1LDIyLjk2ODc1IEM1LjI4NzUsMjIuOTA5Mzc1IDUuMzA5Mzc1LDIyLjg1MzEyNSA1LjM0Njg3NSwyMi44MDYyNSBMMTAuNjY4NzUsMTYuNDkzNzUgQzEwLjc1NjI1LDE2LjM4NzUgMTAuOTE1NjI1LDE2LjM3NSAxMS4wMjE4NzUsMTYuNDYyNSBDMTEuMDMxMjUsMTYuNDcxODc1IDExLjA0Mzc1LDE2LjQ4MTI1IDExLjA1MzEyNSwxNi40OTM3NSBMMTQuMTU5Mzc1LDIwLjE4MTI1IEwxOS4xLDE0LjMyMTg3NSBDMTkuMTg3NSwxNC4yMTU2MjUgMTkuMzQ2ODc1LDE0LjIwMzEyNSAxOS40NTMxMjUsMTQuMjkwNjI1IEMxOS40NjI1LDE0LjMgMTkuNDc1LDE0LjMwOTM3NSAxOS40ODQzNzUsMTQuMzIxODc1IEwyNi42NTkzNzUsMjIuODA5Mzc1IEMyNi43NDA2MjUsMjIuOTEyNSAyNi43MjgxMjUsMjMuMDcxODc1IDI2LjYyMTg3NSwyMy4xNTkzNzUgWiIgaWQ9IlNoYXBlIiBmaWxsPSIjRThFOEU4Ij48L3BhdGg+CiAgICAgICAgICAgIDwvZz4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPg==);
       background-repeat: no-repeat;
       background-position: center center;
+    }
+  }
+
+  &-cover {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    background-color: rgba(0, 0, 0, 0.5);
+    transition: background-color 0.3s;
+
+    &-top {
+      top: 0;
+      left: 0;
+      right: 0;
+      height: max-content;
+      justify-content: flex-start;
+      padding: 5px;
+    }
+    &-bottom {
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: max-content;
+      justify-content: flex-end;
+      padding: 5px;
+    }
+    &-center {
+      top: 50%;
+      left: 0;
+      right: 0;
+      transform: translateY(-50%);
+      height: 100%;
+      align-items: center;
+      justify-content: center;
     }
   }
 

--- a/docs/demo/coverPlacement.md
+++ b/docs/demo/coverPlacement.md
@@ -1,0 +1,8 @@
+---
+title: coverPlacement
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/coverPlacement.tsx"></code>

--- a/docs/examples/coverPlacement.tsx
+++ b/docs/examples/coverPlacement.tsx
@@ -1,0 +1,42 @@
+import type { CoverConfig } from '@rc-component/image';
+import Image from '@rc-component/image';
+import * as React from 'react';
+import '../../assets/index.less';
+import { defaultIcons } from './common';
+
+export default function Base() {
+  const [placement, setPlacement] = React.useState<CoverConfig["placement"]>('center');
+  return (
+    <div>
+      <div>
+        <label htmlFor="placement">
+          <span>placement:</span>
+        </label>
+        <select id="placement" onChange={e => setPlacement(e.target.value as CoverConfig["placement"])} value={placement}>
+          <option value="top">top</option>
+          <option value="bottom">bottom</option>
+          <option value="center">center</option>
+        </select>
+      </div>
+      <br />
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        width={200}
+        onClick={() => {
+          console.log('click');
+        }}
+        preview={{
+          icons: defaultIcons,
+          onOpenChange: open => {
+            console.log('open', open);
+          },
+          zIndex: 9999,
+          cover: {
+            coverNode: 'Click to Preview',
+            placement,
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prettier": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "start": "dumi dev",
     "test": "rc-test",
+    "test:update": "rc-test -u",
     "tsc": "bunx tsc --noEmit"
   },
   "dependencies": {

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -19,8 +19,12 @@ export interface ImgInfo {
   height: string | number;
 }
 
+export interface CoverConfig {
+  coverNode?: React.ReactNode;
+  placement?: 'top' | 'bottom' | 'center';
+}
 export interface PreviewConfig extends Omit<InternalPreviewConfig, 'countRender'> {
-  cover?: React.ReactNode;
+  cover?: React.ReactNode | CoverConfig;
 
   // Similar to InternalPreviewConfig but not have `current`
   imageRender?: (
@@ -120,6 +124,14 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
     rootClassName: previewRootClassName,
     ...restProps
   }: PreviewConfig = preview && typeof preview === 'object' ? preview : {};
+
+  const coverPlacement = typeof cover === 'object' && (cover as CoverConfig).placement ?
+    (cover as CoverConfig).placement || 'center' :
+    'center';
+
+  const coverNode = typeof cover === 'object' && (cover as CoverConfig).coverNode ?
+    (cover as CoverConfig).coverNode :
+    cover as React.ReactNode;
 
   // ============================ Open ============================
   const [isShowPreview, setShowPreview] = useMergedState(!!previewOpen, {
@@ -237,13 +249,13 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
         {/* Preview Click Mask */}
         {cover !== false && canPreview && (
           <div
-            className={classnames(`${prefixCls}-cover`, classNames.cover)}
+            className={classnames(`${prefixCls}-cover`, classNames.cover, `${prefixCls}-cover-${coverPlacement}`)}
             style={{
               display: style?.display === 'none' ? 'none' : undefined,
               ...styles.cover,
             }}
           >
-            {cover}
+            {coverNode}
           </div>
         )}
       </div>

--- a/tests/__snapshots__/basic.test.tsx.snap
+++ b/tests/__snapshots__/basic.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Basic snapshot 1`] = `
     width="200"
   />
   <div
-    class="rc-image-cover"
+    class="rc-image-cover rc-image-cover-center"
   />
 </div>
 `;

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,8 +1,16 @@
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import Image from '../src';
+import Image, { CoverConfig } from '../src';
 
 describe('Basic', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('snapshot', () => {
     const { asFragment } = render(
       <Image
@@ -100,5 +108,53 @@ describe('Basic', () => {
     );
     const operationsElement = baseElement.querySelector('.rc-image-preview');
     expect(operationsElement).toHaveStyle({ zIndex: 9999 });
+  });
+  it('cover placement should work', () => {
+    const App = () => {
+      const [placement, setPlacement] = React.useState<'top' | 'bottom' | 'center'>('center');
+      return (
+        <>
+          <select
+            id="placement"
+            onChange={e => setPlacement(e.target.value as CoverConfig['placement'])}
+            value={placement}
+          >
+            <option value="top">top</option>
+            <option value="bottom">bottom</option>
+            <option value="center">center</option>
+          </select>
+          <Image
+            src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+            preview={{
+              cover: {
+                coverNode: 'Click to Preview',
+                placement: placement as CoverConfig['placement'],
+              },
+            }}
+          />
+        </>
+      );
+    };
+    const { container } = render(<App />);
+    const coverElement = container.querySelector('.rc-image-cover');
+    expect(coverElement).toHaveClass('rc-image-cover-center');
+
+    fireEvent.change(container.querySelector('#placement'), {
+      target: { value: 'top' },
+    });
+    // Wait for the state update to take effect
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(coverElement).toHaveClass('rc-image-cover-top');
+
+    fireEvent.change(container.querySelector('#placement'), {
+      target: { value: 'bottom' },
+    });
+    // Wait for the state update to take effect
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(coverElement).toHaveClass('rc-image-cover-bottom');
   });
 });


### PR DESCRIPTION
- https://github.com/ant-design/ant-design/issues/54348

<img width="275" height="316" alt="image" src="https://github.com/user-attachments/assets/740155d7-ff0e-4d92-b14b-3cdd63652737" />
<img width="267" height="314" alt="image" src="https://github.com/user-attachments/assets/1c39aa2f-ee00-4990-92c8-623d6959befe" />
<img width="264" height="308" alt="image" src="https://github.com/user-attachments/assets/66c7f8f1-ab3f-4821-b429-2b2d38a4050f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 图片预览支持自定义覆盖层（cover）的内容及其位置，可选择顶部、底部或居中显示。
  * 新增图片覆盖层的样式和结构，提升内容展示的灵活性。
  * 新增演示文档和示例，展示覆盖层位置控制功能。

* **测试**
  * 增加了针对覆盖层位置切换的测试用例，确保功能稳定。

* **文档**
  * 新增了关于覆盖层位置功能的使用说明和示例文档。

* **杂项**
  * 新增测试快照更新脚本，便于维护测试用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->