### PR TITLE
feat: video preview type

### DIFF
--- a/assets/preview.less
+++ b/assets/preview.less
@@ -25,7 +25,8 @@
     }
   }
 
-  &-img {
+  &-img,
+  &-video {
     max-width: 100%;
     max-height: 70%;
   }

--- a/docs/demo/previewvideo.md
+++ b/docs/demo/previewvideo.md
@@ -1,0 +1,8 @@
+---
+title: previewvideo
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/previewvideo.tsx"></code>

--- a/docs/examples/previewvideo.tsx
+++ b/docs/examples/previewvideo.tsx
@@ -1,0 +1,42 @@
+import Image from '@rc-component/image';
+import * as React from 'react';
+import '../../assets/index.less';
+import { defaultIcons } from './common';
+
+export default function PreviewVideo() {
+  return (
+    <div>
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png?x-oss-process=image/auto-orient,1/resize,p_10/quality,q_10"
+        preview={{
+          icons: defaultIcons,
+          type: 'video',
+          src: 'https://gw.alipayobjects.com/os/rmsportal/NTMlQdLIkPjOACXsdRrq.mp4',
+        }}
+        width={200}
+      />
+
+      <br />
+      <h1>PreviewGroup</h1>
+      <Image.PreviewGroup preview={{ icons: defaultIcons }}>
+        <Image
+          key={1}
+          src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+          preview={{
+            src: 'https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png',
+          }}
+          width={200}
+        />
+        <Image
+          key={2}
+          src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+          preview={{
+            type: 'video',
+            src: 'https://gw.alipayobjects.com/os/rmsportal/NTMlQdLIkPjOACXsdRrq.mp4',
+          }}
+          width={200}
+        />
+      </Image.PreviewGroup>
+    </div>
+  );
+}

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -117,6 +117,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
   const canPreview = !!preview;
 
   const {
+    type: previewType = 'image',
     src: previewSrc,
     open: previewOpen,
     onOpenChange: onPreviewOpenChange,
@@ -178,8 +179,9 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
     () => ({
       ...imgCommonProps,
       src,
+      type: previewType,
     }),
-    [src, imgCommonProps],
+    [src, imgCommonProps, previewType],
   );
 
   const imageId = useRegisterImage(canPreview, registerData);
@@ -266,6 +268,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
           prefixCls={previewPrefixCls}
           onClose={onPreviewClose}
           mousePosition={mousePosition}
+          type={previewType}
           src={src}
           alt={alt}
           imageInfo={{ width, height }}

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -72,7 +72,8 @@ export interface InternalPreviewConfig {
   /** Better to use `classNames.root` instead */
   rootClassName?: string;
 
-  // Image
+  // Media
+  type?: 'image' | 'video';
   src?: string;
   alt?: string;
 
@@ -121,7 +122,7 @@ export interface PreviewProps extends InternalPreviewConfig {
   };
   fallback?: string;
 
-  // Preview image
+  // Preview media
   imgCommonProps?: React.ImgHTMLAttributes<HTMLImageElement>;
   width?: string | number;
   height?: string | number;
@@ -165,6 +166,7 @@ const Preview: React.FC<PreviewProps> = props => {
   const {
     prefixCls,
     rootClassName,
+    type = 'image',
     src,
     alt,
     imageInfo,
@@ -425,13 +427,24 @@ const Preview: React.FC<PreviewProps> = props => {
               {/* Body */}
               <div className={classnames(`${prefixCls}-body`, classNames.body)} style={bodyStyle}>
                 {/* Preview Image */}
-                {imageRender
-                  ? imageRender(imgNode, {
-                      transform,
-                      image,
-                      ...(groupContext ? { current } : {}),
-                    })
-                  : imgNode}
+                {type === 'image' &&
+                  (imageRender
+                    ? imageRender(imgNode, {
+                        transform,
+                        image,
+                        ...(groupContext ? { current } : {}),
+                      })
+                    : imgNode)}
+                {type === 'video' && (
+                  <video
+                    className={`${prefixCls}-video`}
+                    src={src}
+                    width={props.width}
+                    height={props.height}
+                    controls
+                    autoPlay
+                  />
+                )}
               </div>
 
               {/* Close Button */}
@@ -454,37 +467,38 @@ const Preview: React.FC<PreviewProps> = props => {
                 />
               )}
 
-              {/* Footer */}
-              <Footer
-                prefixCls={prefixCls}
-                showProgress={showOperationsProgress}
-                current={current}
-                count={count}
-                showSwitch={showLeftOrRightSwitches}
-                // Style
-                classNames={classNames}
-                styles={styles}
-                // Render
-                image={image}
-                transform={transform}
-                icons={icons}
-                countRender={countRender}
-                actionsRender={actionsRender}
-                // Scale
-                scale={scale}
-                minScale={minScale}
-                maxScale={maxScale}
-                // Actions
-                onActive={onActive}
-                onFlipY={onFlipY}
-                onFlipX={onFlipX}
-                onRotateLeft={onRotateLeft}
-                onRotateRight={onRotateRight}
-                onZoomOut={onZoomOut}
-                onZoomIn={onZoomIn}
-                onClose={onClose}
-                onReset={onReset}
-              />
+              {type === 'image' && (
+                <Footer
+                  prefixCls={prefixCls}
+                  showProgress={showOperationsProgress}
+                  current={current}
+                  count={count}
+                  showSwitch={showLeftOrRightSwitches}
+                  // Style
+                  classNames={classNames}
+                  styles={styles}
+                  // Render
+                  image={image}
+                  transform={transform}
+                  icons={icons}
+                  countRender={countRender}
+                  actionsRender={actionsRender}
+                  // Scale
+                  scale={scale}
+                  minScale={minScale}
+                  maxScale={maxScale}
+                  // Actions
+                  onActive={onActive}
+                  onFlipY={onFlipY}
+                  onFlipX={onFlipX}
+                  onRotateLeft={onRotateLeft}
+                  onRotateRight={onRotateRight}
+                  onZoomOut={onZoomOut}
+                  onZoomIn={onZoomIn}
+                  onClose={onClose}
+                  onReset={onReset}
+                />
+              )}
             </div>
           );
         }}

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -67,7 +67,7 @@ const Group: React.FC<PreviewGroupProps> = ({
   const [keepOpenIndex, setKeepOpenIndex] = useState(false);
 
   // >>> Image
-  const { src, ...imgCommonProps } = mergedItems[current]?.data || {};
+  const { src, type, ...imgCommonProps } = mergedItems[current]?.data || {};
   // >>> Visible
   const [isShowPreview, setShowPreview] = useMergedState(!!previewOpen, {
     value: previewOpen,
@@ -136,6 +136,7 @@ const Group: React.FC<PreviewGroupProps> = ({
         mousePosition={mousePosition}
         imgCommonProps={imgCommonProps}
         src={src}
+        type={type}
         fallback={fallback}
         icons={icons}
         current={current}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -13,7 +13,7 @@ export type ImageElementProps = Pick<
   | 'srcSet'
   | 'useMap'
   | 'alt'
->;
+> & { type?: 'image' | 'video' };
 
 export type PreviewImageElementProps = {
   data: ImageElementProps;


### PR DESCRIPTION
近些年的 Web 应用中，图片和视频混排的情况非常多，因此希望在 Image 组件中支持视频预览，效果类似于 Twitter/X 的多图帖子。视频预览没有工具栏，仅有翻页和关闭按钮。

```jsx
<Image
  src="/cover.jpg"
  preview={{
    type: 'video',
    src: '/video.mp4'
  }}
/>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- 新功能
  - 预览新增支持视频，视频在预览中与图片一致交互；在预览组中可混合展示图片与视频，默认仍为图片类型。
- 文档
  - 新增“预览视频”示例与演示页面，包含单个视频预览与混合预览组示例，便于参考使用。
- 样式
  - 统一预览媒体的尺寸约束（最大宽高）到图片与视频，显示更一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->