### PR TITLE
refactor: Upgrade utils and replace useMergedState

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@rc-component/portal": "^2.0.0",
     "@rc-component/motion": "^1.0.0",
-    "@rc-component/util": "^1.0.0",
+    "@rc-component/util": "^1.3.0",
     "classnames": "^2.2.6"
   },
   "devDependencies": {

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -1,4 +1,4 @@
-import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
+import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
 import classnames from 'classnames';
 import * as React from 'react';
 import { useContext, useMemo, useState } from 'react';
@@ -125,18 +125,18 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
     ...restProps
   }: PreviewConfig = preview && typeof preview === 'object' ? preview : {};
 
-  const coverPlacement = typeof cover === 'object' && (cover as CoverConfig).placement ?
-    (cover as CoverConfig).placement || 'center' :
-    'center';
+  const coverPlacement =
+    typeof cover === 'object' && (cover as CoverConfig).placement
+      ? (cover as CoverConfig).placement || 'center'
+      : 'center';
 
-  const coverNode = typeof cover === 'object' && (cover as CoverConfig).coverNode ?
-    (cover as CoverConfig).coverNode :
-    cover as React.ReactNode;
+  const coverNode =
+    typeof cover === 'object' && (cover as CoverConfig).coverNode
+      ? (cover as CoverConfig).coverNode
+      : (cover as React.ReactNode);
 
   // ============================ Open ============================
-  const [isShowPreview, setShowPreview] = useMergedState(!!previewOpen, {
-    value: previewOpen,
-  });
+  const [isShowPreview, setShowPreview] = useControlledState(!!previewOpen, previewOpen);
 
   const [mousePosition, setMousePosition] = useState<null | { x: number; y: number }>(null);
 
@@ -249,7 +249,11 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
         {/* Preview Click Mask */}
         {cover !== false && canPreview && (
           <div
-            className={classnames(`${prefixCls}-cover`, classNames.cover, `${prefixCls}-cover-${coverPlacement}`)}
+            className={classnames(
+              `${prefixCls}-cover`,
+              classNames.cover,
+              `${prefixCls}-cover-${coverPlacement}`,
+            )}
             style={{
               display: style?.display === 'none' ? 'none' : undefined,
               ...styles.cover,

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -71,7 +71,7 @@ const Group: React.FC<PreviewGroupProps> = ({
 
   React.useEffect(() => {
     onOpenChange?.(isShowPreview, { current });
-  }, [isShowPreview]);
+  }, [isShowPreview, current, onOpenChange]);
 
   // >>> Position
   const [mousePosition, setMousePosition] = useState<null | { x: number; y: number }>(null);

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -1,4 +1,5 @@
 import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
+import useEvent from '@rc-component/util/lib/hooks/useEvent';
 import * as React from 'react';
 import { useState } from 'react';
 import type { ImgInfo } from './Image';
@@ -68,10 +69,12 @@ const Group: React.FC<PreviewGroupProps> = ({
   const { src, ...imgCommonProps } = mergedItems[current]?.data || {};
   // >>> Visible
   const [isShowPreview, setShowPreview] = useControlledState(!!previewOpen, previewOpen);
-
-  React.useEffect(() => {
-    onOpenChange?.(isShowPreview, { current });
-  }, [isShowPreview, current, onOpenChange]);
+  const triggerShowPreview = useEvent((next: boolean) => {
+    setShowPreview(next);
+    if (next !== isShowPreview) {
+      onOpenChange?.(next, { current });
+    }
+  });
 
   // >>> Position
   const [mousePosition, setMousePosition] = useState<null | { x: number; y: number }>(null);
@@ -84,7 +87,7 @@ const Group: React.FC<PreviewGroupProps> = ({
 
       setCurrent(index < 0 ? 0 : index);
 
-      setShowPreview(true);
+      triggerShowPreview(true);
       setMousePosition({ x: mouseX, y: mouseY });
 
       setKeepOpenIndex(true);
@@ -111,7 +114,7 @@ const Group: React.FC<PreviewGroupProps> = ({
   };
 
   const onPreviewClose = () => {
-    setShowPreview(false);
+    triggerShowPreview(false);
     setMousePosition(null);
   };
 

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -1,4 +1,4 @@
-import useMergedState from '@rc-component/util/lib/hooks/useMergedState';
+import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
 import * as React from 'react';
 import { useState } from 'react';
 import type { ImgInfo } from './Image';
@@ -60,21 +60,18 @@ const Group: React.FC<PreviewGroupProps> = ({
 
   // ========================= Preview ==========================
   // >>> Index
-  const [current, setCurrent] = useMergedState(0, {
-    value: currentIndex,
-  });
+  const [current, setCurrent] = useControlledState(0, currentIndex);
 
   const [keepOpenIndex, setKeepOpenIndex] = useState(false);
 
   // >>> Image
   const { src, ...imgCommonProps } = mergedItems[current]?.data || {};
   // >>> Visible
-  const [isShowPreview, setShowPreview] = useMergedState(!!previewOpen, {
-    value: previewOpen,
-    onChange: val => {
-      onOpenChange?.(val, { current });
-    },
-  });
+  const [isShowPreview, setShowPreview] = useControlledState(!!previewOpen, previewOpen);
+
+  React.useEffect(() => {
+    onOpenChange?.(isShowPreview, { current });
+  }, [isShowPreview]);
 
   // >>> Position
   const [mousePosition, setMousePosition] = useState<null | { x: number; y: number }>(null);


### PR DESCRIPTION
关联issue：https://github.com/ant-design/ant-design/issues/54854
替换 useMergedState 为 useControlledState

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 统一预览相关组件的受控状态管理，提升受控/非受控行为的一致性与可维护性
  - 优化预览开启状态与当前索引的同步，改进可预测性与稳定性，确保打开/关闭和索引变更时回调触发更可靠
- Chores
  - 升级依赖 @rc-component/util 至 1.3.0，获得相关修复与改进
<!-- end of auto-generated comment: release notes by coderabbit.ai -->