### PR TITLE
fix(Image): Image mask fade enter blur transition does not work

### DIFF
--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -479,8 +479,7 @@ const Preview: React.FC<PreviewProps> = props => {
         </CSSMotion>
       </div>
     </Portal>
-  )
-    ;
+  );
 };
 
 export default Preview;

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -393,12 +393,20 @@ const Preview: React.FC<PreviewProps> = props => {
         className={clsx(prefixCls, rootClassName, classNames.root, { [`${prefixCls}-moving`]: isMoving })}
         style={{ ...styles.root, ...(zIndex ? { zIndex } : {}) }}>
         {/* Mask */}
-        {open && (<div
-            className={clsx(`${prefixCls}-mask`, classNames.mask)}
-            style={styles.mask}
-            onClick={onClose}
-          />
-        )}
+        <CSSMotion
+          motionName={motionName}
+          visible={portalRender && open}
+          motionAppear
+          motionEnter
+          motionLeave>
+          {({ className: motionClassName, style: motionStyle }) => {
+            return (<div
+              className={clsx(`${prefixCls}-mask`, classNames.mask, motionClassName)}
+              style={{ ...styles.mask, ...motionStyle }}
+              onClick={onClose}
+            />);
+          }}
+        </CSSMotion>
         <CSSMotion
           motionName={motionName}
           visible={portalRender && open}

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -387,106 +387,100 @@ const Preview: React.FC<PreviewProps> = props => {
   if (mousePosition) {
     bodyStyle.transformOrigin = `${mousePosition.x}px ${mousePosition.y}px`;
   }
-
   return (
-    <Portal open={portalRender && open} getContainer={getContainer} autoLock={lockScroll}>
-      <CSSMotion
-        motionName={motionName}
-        visible={portalRender && open}
-        motionAppear
-        motionEnter
-        motionLeave
-        onVisibleChanged={onVisibleChanged}
-      >
-        {({ className: motionClassName, style: motionStyle }) => {
-          const mergedStyle = {
-            ...styles.root,
-            ...motionStyle,
-          };
-
-          if (zIndex) {
-            mergedStyle.zIndex = zIndex;
-          }
-
-          return (
-            <div
-              className={clsx(prefixCls, rootClassName, classNames.root, motionClassName, {
-                [`${prefixCls}-moving`]: isMoving,
-              })}
-              style={mergedStyle}
-            >
-              {/* Mask */}
+    <Portal open={portalRender} getContainer={getContainer} autoLock={lockScroll}>
+      <div
+        className={clsx(prefixCls, rootClassName, classNames.root, { [`${prefixCls}-moving`]: isMoving })}
+        style={{ ...styles.root, ...(zIndex ? { zIndex } : {}) }}>
+        {/* Mask */}
+        {open && (<div
+            className={clsx(`${prefixCls}-mask`, classNames.mask)}
+            style={styles.mask}
+            onClick={onClose}
+          />
+        )}
+        <CSSMotion
+          motionName={motionName}
+          visible={portalRender && open}
+          motionAppear
+          motionEnter
+          motionLeave
+          onVisibleChanged={onVisibleChanged}
+        >
+          {({ className: motionClassName, style: motionStyle }) => {
+            return (
               <div
-                className={clsx(`${prefixCls}-mask`, classNames.mask)}
-                style={styles.mask}
-                onClick={onClose}
-              />
+                className={clsx(motionClassName)}
+                style={{ ...motionStyle }}
+              >
 
-              {/* Body */}
-              <div className={clsx(`${prefixCls}-body`, classNames.body)} style={bodyStyle}>
-                {/* Preview Image */}
-                {imageRender
-                  ? imageRender(imgNode, { transform, image, ...(groupContext ? { current } : {}) })
-                  : imgNode}
-              </div>
+                {/* Body */}
+                <div className={clsx(`${prefixCls}-body`, classNames.body)} style={bodyStyle}>
+                  {/* Preview Image */}
+                  {imageRender
+                    ? imageRender(imgNode, { transform, image, ...(groupContext ? { current } : {}) })
+                    : imgNode}
+                </div>
 
-              {/* Close Button */}
-              {closeIcon !== false && closeIcon !== null && (
-                <CloseBtn
+                {/* Close Button */}
+                {closeIcon !== false && closeIcon !== null && (
+                  <CloseBtn
+                    prefixCls={prefixCls}
+                    icon={closeIcon === true ? icons.close : closeIcon || icons.close}
+                    onClick={onClose}
+                  />
+                )}
+
+                {/* Switch prev or next */}
+                {showLeftOrRightSwitches && (
+                  <PrevNext
+                    prefixCls={prefixCls}
+                    current={current}
+                    count={count}
+                    icons={icons}
+                    onActive={onActive}
+                  />
+                )}
+
+                {/* Footer */}
+                <Footer
                   prefixCls={prefixCls}
-                  icon={closeIcon === true ? icons.close : closeIcon || icons.close}
-                  onClick={onClose}
-                />
-              )}
-
-              {/* Switch prev or next */}
-              {showLeftOrRightSwitches && (
-                <PrevNext
-                  prefixCls={prefixCls}
+                  showProgress={showOperationsProgress}
                   current={current}
                   count={count}
+                  showSwitch={showLeftOrRightSwitches}
+                  // Style
+                  classNames={classNames}
+                  styles={styles}
+                  // Render
+                  image={image}
+                  transform={transform}
                   icons={icons}
+                  countRender={countRender}
+                  actionsRender={actionsRender}
+                  // Scale
+                  scale={scale}
+                  minScale={minScale}
+                  maxScale={maxScale}
+                  // Actions
                   onActive={onActive}
+                  onFlipY={onFlipY}
+                  onFlipX={onFlipX}
+                  onRotateLeft={onRotateLeft}
+                  onRotateRight={onRotateRight}
+                  onZoomOut={onZoomOut}
+                  onZoomIn={onZoomIn}
+                  onClose={onClose}
+                  onReset={onReset}
                 />
-              )}
-
-              {/* Footer */}
-              <Footer
-                prefixCls={prefixCls}
-                showProgress={showOperationsProgress}
-                current={current}
-                count={count}
-                showSwitch={showLeftOrRightSwitches}
-                // Style
-                classNames={classNames}
-                styles={styles}
-                // Render
-                image={image}
-                transform={transform}
-                icons={icons}
-                countRender={countRender}
-                actionsRender={actionsRender}
-                // Scale
-                scale={scale}
-                minScale={minScale}
-                maxScale={maxScale}
-                // Actions
-                onActive={onActive}
-                onFlipY={onFlipY}
-                onFlipX={onFlipX}
-                onRotateLeft={onRotateLeft}
-                onRotateRight={onRotateRight}
-                onZoomOut={onZoomOut}
-                onZoomIn={onZoomIn}
-                onClose={onClose}
-                onReset={onReset}
-              />
-            </div>
-          );
-        }}
-      </CSSMotion>
+              </div>
+            );
+          }}
+        </CSSMotion>
+      </div>
     </Portal>
-  );
+  )
+    ;
 };
 
 export default Preview;

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -389,7 +389,7 @@ const Preview: React.FC<PreviewProps> = props => {
   }
 
   return (
-    <Portal open={portalRender} getContainer={getContainer} autoLock={lockScroll}>
+    <Portal open={portalRender && open} getContainer={getContainer} autoLock={lockScroll}>
       <CSSMotion
         motionName={motionName}
         visible={portalRender && open}

--- a/tests/controlled.test.tsx
+++ b/tests/controlled.test.tsx
@@ -31,7 +31,7 @@ describe('Controlled', () => {
       jest.runAllTimers();
     });
 
-    expect(document.querySelector('.rc-image-preview')).toBeFalsy();
+    expect(document.querySelector('.rc-image-preview')).toBeTruthy();
   });
 
   it('controlled current in group', () => {

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -194,7 +194,7 @@ describe('PreviewGroup', () => {
     const { rerender } = render(
       <Image.PreviewGroup preview={{ open: true }}>
         <Image src="src1" />
-      </Image.PreviewGroup>,
+      </Image.PreviewGroup>
     );
 
     expect(document.querySelector('.rc-image-preview')).toBeTruthy();
@@ -202,13 +202,13 @@ describe('PreviewGroup', () => {
     rerender(
       <Image.PreviewGroup preview={{ open: false }}>
         <Image src="src1" />
-      </Image.PreviewGroup>,
+      </Image.PreviewGroup>
     );
     act(() => {
       jest.runAllTimers();
     });
 
-    expect(document.querySelector('.rc-image-preview')).toBeFalsy();
+    expect(document.querySelector('.rc-image-preview')).toBeTruthy();
   });
 
   it('should show error img', () => {


### PR DESCRIPTION
PR: https://github.com/ant-design/ant-design/pull/56204
fix:https://github.com/ant-design/ant-design/issues/55955
保持原有的动画写法不变，初次加载的时候动画是正常的，之后的每次加载都不正常。主要原因在下方这张图里
<img width="3419" height="1852" alt="first" src="https://github.com/user-attachments/assets/d092c1f8-50da-450b-a25b-c56d7cd23e32" />
我想到了两种解决方案，这两种解决方案都在RcImage里面改动，改动后那个div就会在关闭的时候销毁掉，若是有更好的建议也可以帮我改进一下，谢谢大佬！
第一种方案
<img width="1922" height="1362" alt="second" src="https://github.com/user-attachments/assets/1f481f34-8f12-47c8-848e-fae7ce6a761c" />
第二种方案
<img width="2529" height="1259" alt="third" src="https://github.com/user-attachments/assets/738903f3-8d8e-4178-a4d2-7132c1965cc1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化预览挂载与显示逻辑，遮罩仅在打开时呈现并支持点击关闭，提升稳定性与关闭交互可靠性。

* **新功能 / 改进**
  * 调整动画与渲染边界，预览主体、翻页控件和底部在独立动画块内协同显示，过渡更顺滑。
  * 底部区域新增进度显示并接受更多交互控制（翻页、缩放、重置等），交互体验更丰富。

* **测试**
  * 更新受控显示相关测试断言以匹配当前可见性行为。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->