### PR TITLE
fix: 释放事件同样需要 movable 为 true

### DIFF
--- a/src/hooks/useMouseEvent.ts
+++ b/src/hooks/useMouseEvent.ts
@@ -115,15 +115,17 @@ export default function useMouseEvent(
     }
 
     return () => {
-      window.removeEventListener('mouseup', onMouseUp);
-      window.removeEventListener('mousemove', onMouseMove);
+      if (movable) {
+        window.removeEventListener('mouseup', onMouseUp);
+        window.removeEventListener('mousemove', onMouseMove);
 
-      /* istanbul ignore next */
-      try {
-        window.top?.removeEventListener('mouseup', onMouseUp);
-        window.top?.removeEventListener('mousemove', onMouseMove);
-      } catch (error) {
-        // Do nothing
+        /* istanbul ignore next */
+        try {
+          window.top?.removeEventListener('mouseup', onMouseUp);
+          window.top?.removeEventListener('mousemove', onMouseMove);
+        } catch (error) {
+          // Do nothing
+        }
       }
     };
   }, [open, isMoving, x, y, rotate, movable]);


### PR DESCRIPTION
使用 iframe 去访问一个使用了当前组件的页面，页面会报错，原因是使用了 window.top 且无法 try catch， 页面直接白屏

所以修正下逻辑只有在 movable 为 true 时，才会执行 window.top?.removeEventListener，这样我们在业务上可以通过关闭 movable 防止跨域白屏问题

#482 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了鼠标事件监听器的清理逻辑，确保底部鼠标事件和顶层事件监听器在正确的条件下被移除，增强了应用的稳定性和事件处理的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->