### PR TITLE
feat: improve Image preview accessibility

### DIFF
--- a/assets/preview.less
+++ b/assets/preview.less
@@ -58,9 +58,12 @@
     height: 40px;
     color: #fff;
     background: rgba(0, 0, 0, 0.3);
+    border: 0;
+    padding: 0;
     border-radius: 9999px;
     transform: translateY(-50%);
     cursor: pointer;
+    font: inherit;
 
     &-disabled {
       cursor: default;
@@ -104,6 +107,10 @@
     &-action {
       color: #fff;
       cursor: pointer;
+      border: 0;
+      padding: 0;
+      background: transparent;
+      font: inherit;
 
       &-disabled {
         cursor: default;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@rc-component/motion": "^1.0.0",
     "@rc-component/portal": "^2.1.2",
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.10.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -203,6 +203,18 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
     onClick?.(e);
   };
 
+  // ======================= Keyboard Preview =====================
+  const onPreviewKeyDown: React.KeyboardEventHandler<HTMLDivElement> = event => {
+    if (!canPreview) {
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onPreview(event as any);
+    }
+  };
+
   // =========================== Render ===========================
   return (
     <>
@@ -212,6 +224,10 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
           [`${prefixCls}-error`]: status === 'error',
         })}
         onClick={canPreview ? onPreview : onClick}
+        role={canPreview ? 'button' : otherProps.role}
+        tabIndex={canPreview && otherProps.tabIndex == null ? 0 : otherProps.tabIndex}
+        aria-label={canPreview ? (alt || 'Preview image') : otherProps['aria-label']}
+        onKeyDown={onPreviewKeyDown}
         style={{
           width,
           height,

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -211,7 +211,20 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
 
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      onPreview(event as any);
+
+      const rect = (event.target as HTMLDivElement).getBoundingClientRect();
+      const left = rect.x + rect.width / 2;
+      const top = rect.y + rect.height / 2;
+
+      if (groupContext) {
+        groupContext.onPreview(imageId, src, left, top);
+      } else {
+        setMousePosition({
+          x: left,
+          y: top,
+        });
+        triggerPreviewOpen(true);
+      }
     }
   };
 
@@ -226,8 +239,13 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
         onClick={canPreview ? onPreview : onClick}
         role={canPreview ? 'button' : otherProps.role}
         tabIndex={canPreview && otherProps.tabIndex == null ? 0 : otherProps.tabIndex}
-        aria-label={canPreview ? (alt || 'Preview image') : otherProps['aria-label']}
-        onKeyDown={onPreviewKeyDown}
+        aria-label={
+          canPreview ? (otherProps['aria-label'] ?? alt ?? 'Preview image') : otherProps['aria-label']
+        }
+        onKeyDown={event => {
+          onPreviewKeyDown(event);
+          (otherProps as any).onKeyDown?.(event);
+        }}
         style={{
           width,
           height,

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -240,7 +240,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
         role={canPreview ? 'button' : otherProps.role}
         tabIndex={canPreview && otherProps.tabIndex == null ? 0 : otherProps.tabIndex}
         aria-label={
-          canPreview ? (otherProps['aria-label'] ?? alt ?? 'Preview image') : otherProps['aria-label']
+          canPreview ? (otherProps['aria-label'] ?? alt) : otherProps['aria-label']
         }
         onKeyDown={event => {
           onPreviewKeyDown(event);

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -44,7 +44,7 @@ export interface PreviewConfig extends Omit<InternalPreviewConfig, 'countRender'
 export type SemanticName = 'root' | 'image' | 'cover';
 
 export interface ImageProps
-  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onClick'> {
+  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'onClick' | 'onKeyDown'> {
   // Misc
   prefixCls?: string;
   previewPrefixCls?: string;
@@ -73,6 +73,7 @@ export interface ImageProps
   // Events
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
   onError?: (e: React.SyntheticEvent<HTMLImageElement, Event>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
 }
 
 interface CompoundedComponent<P> extends React.FC<P> {
@@ -108,6 +109,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
     // Events
     onClick,
     onError,
+    onKeyDown,
     ...otherProps
   } = props;
 
@@ -205,6 +207,8 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
 
   // ======================= Keyboard Preview =====================
   const onPreviewKeyDown: React.KeyboardEventHandler<HTMLDivElement> = event => {
+    onKeyDown?.(event);
+
     if (!canPreview) {
       return;
     }
@@ -239,13 +243,8 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
         onClick={canPreview ? onPreview : onClick}
         role={canPreview ? 'button' : otherProps.role}
         tabIndex={canPreview && otherProps.tabIndex == null ? 0 : otherProps.tabIndex}
-        aria-label={
-          canPreview ? (otherProps['aria-label'] ?? alt) : otherProps['aria-label']
-        }
-        onKeyDown={event => {
-          onPreviewKeyDown(event);
-          (otherProps as any).onKeyDown?.(event);
-        }}
+        aria-label={canPreview ? otherProps['aria-label'] ?? alt : otherProps['aria-label']}
+        onKeyDown={onPreviewKeyDown}
         style={{
           width,
           height,

--- a/src/Preview/Footer.tsx
+++ b/src/Preview/Footer.tsx
@@ -95,15 +95,18 @@ export default function Footer(props: FooterProps) {
 
   const renderOperation = ({ type, disabled, onClick, icon }: RenderOperationParams) => {
     return (
-      <div
+      <button
+        type="button"
         key={type}
         className={clsx(actionCls, `${actionCls}-${type}`, {
           [`${actionCls}-disabled`]: !!disabled,
         })}
         onClick={onClick}
+        disabled={!!disabled}
+        aria-label={type}
       >
         {icon}
-      </div>
+      </button>
     );
   };
 

--- a/src/Preview/Footer.tsx
+++ b/src/Preview/Footer.tsx
@@ -20,7 +20,7 @@ interface RenderOperationParams {
   icon: React.ReactNode;
   type: OperationType;
   disabled?: boolean;
-  onClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export interface FooterProps extends Actions {

--- a/src/Preview/PrevNext.tsx
+++ b/src/Preview/PrevNext.tsx
@@ -23,22 +23,28 @@ export default function PrevNext(props: PrevNextProps) {
 
   return (
     <>
-      <div
+      <button
+        type="button"
         className={clsx(switchCls, `${switchCls}-prev`, {
           [`${switchCls}-disabled`]: current === 0,
         })}
         onClick={() => onActive(-1)}
+        disabled={current === 0}
+        aria-label="Previous image"
       >
         {prev ?? left}
-      </div>
-      <div
+      </button>
+      <button
+        type="button"
         className={clsx(switchCls, `${switchCls}-next`, {
           [`${switchCls}-disabled`]: current === count - 1,
         })}
         onClick={() => onActive(1)}
+        disabled={current === count - 1}
+        aria-label="Next image"
       >
         {next ?? right}
-      </div>
+      </button>
     </>
   );
 }

--- a/src/Preview/PrevNext.tsx
+++ b/src/Preview/PrevNext.tsx
@@ -21,25 +21,27 @@ export default function PrevNext(props: PrevNextProps) {
 
   const switchCls = `${prefixCls}-switch`;
 
+  const prevDisabled = current === 0;
+  const nextDisabled = current === count - 1;
+
   return (
     <>
       <button
-        type="button"
         className={clsx(switchCls, `${switchCls}-prev`, {
-          [`${switchCls}-disabled`]: current === 0,
+          [`${switchCls}-disabled`]: prevDisabled,
         })}
         onClick={() => onActive(-1)}
-        disabled={current === 0}
+        disabled={prevDisabled}
       >
         {prev ?? left}
       </button>
       <button
         type="button"
         className={clsx(switchCls, `${switchCls}-next`, {
-          [`${switchCls}-disabled`]: current === count - 1,
+          [`${switchCls}-disabled`]: nextDisabled,
         })}
         onClick={() => onActive(1)}
-        disabled={current === count - 1}
+        disabled={nextDisabled}
       >
         {next ?? right}
       </button>

--- a/src/Preview/PrevNext.tsx
+++ b/src/Preview/PrevNext.tsx
@@ -30,7 +30,6 @@ export default function PrevNext(props: PrevNextProps) {
         })}
         onClick={() => onActive(-1)}
         disabled={current === 0}
-        aria-label="Previous image"
       >
         {prev ?? left}
       </button>
@@ -41,7 +40,6 @@ export default function PrevNext(props: PrevNextProps) {
         })}
         onClick={() => onActive(1)}
         disabled={current === count - 1}
-        aria-label="Next image"
       >
         {next ?? right}
       </button>

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -195,6 +195,8 @@ const Preview: React.FC<PreviewProps> = props => {
   } = props;
 
   const imgRef = useRef<HTMLImageElement>();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const lastActiveRef = useRef<HTMLElement | null>(null);
   const groupContext = useContext(PreviewGroupContext);
   const showLeftOrRightSwitches = groupContext && count > 1;
   const showOperationsProgress = groupContext && count >= 1;
@@ -236,6 +238,20 @@ const Preview: React.FC<PreviewProps> = props => {
   useEffect(() => {
     if (!open) {
       resetTransform('close');
+    }
+  }, [open]);
+
+  // =========================== Focus ============================
+  useEffect(() => {
+    if (open) {
+      lastActiveRef.current = (document.activeElement as HTMLElement) || null;
+
+      if (wrapperRef.current) {
+        wrapperRef.current.focus();
+      }
+    } else if (!open && lastActiveRef.current) {
+      lastActiveRef.current.focus();
+      lastActiveRef.current = null;
     }
   }, [open]);
 
@@ -418,10 +434,15 @@ const Preview: React.FC<PreviewProps> = props => {
 
           return (
             <div
+              ref={wrapperRef}
               className={clsx(prefixCls, rootClassName, classNames.root, motionClassName, {
                 [`${prefixCls}-moving`]: isMoving,
               })}
               style={mergedStyle}
+              role="dialog"
+              aria-modal="true"
+              aria-label={alt || 'Image preview'}
+              tabIndex={-1}
             >
               {/* Mask */}
               <div

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -388,15 +388,15 @@ const Preview: React.FC<PreviewProps> = props => {
   useEffect(() => {
     if (open) {
       lastActiveRef.current = (document.activeElement as HTMLElement) || null;
-
-      // When `open` is initially true, the portal content is rendered in a later effect.
-      // Depend on `portalRender` so we can focus once the wrapper is actually mounted.
-      if (wrapperRef.current && portalRender) {
-        wrapperRef.current.focus();
-      }
-    } else if (!open && lastActiveRef.current) {
+    } else if (lastActiveRef.current) {
       lastActiveRef.current.focus();
       lastActiveRef.current = null;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (open && portalRender && wrapperRef.current) {
+      wrapperRef.current.focus();
     }
   }, [open, portalRender]);
 

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -241,20 +241,6 @@ const Preview: React.FC<PreviewProps> = props => {
     }
   }, [open]);
 
-  // =========================== Focus ============================
-  useEffect(() => {
-    if (open) {
-      lastActiveRef.current = (document.activeElement as HTMLElement) || null;
-
-      if (wrapperRef.current) {
-        wrapperRef.current.focus();
-      }
-    } else if (!open && lastActiveRef.current) {
-      lastActiveRef.current.focus();
-      lastActiveRef.current = null;
-    }
-  }, [open]);
-
   // ========================== Image ===========================
   const onDoubleClick = (event: React.MouseEvent<HTMLImageElement, MouseEvent>) => {
     if (open) {
@@ -397,6 +383,22 @@ const Preview: React.FC<PreviewProps> = props => {
       onClose?.();
     }
   };
+
+  // =========================== Focus ============================
+  useEffect(() => {
+    if (open) {
+      lastActiveRef.current = (document.activeElement as HTMLElement) || null;
+
+      // When `open` is initially true, the portal content is rendered in a later effect.
+      // Depend on `portalRender` so we can focus once the wrapper is actually mounted.
+      if (wrapperRef.current && portalRender) {
+        wrapperRef.current.focus();
+      }
+    } else if (!open && lastActiveRef.current) {
+      lastActiveRef.current.focus();
+      lastActiveRef.current = null;
+    }
+  }, [open, portalRender]);
 
   // ========================== Render ==========================
   const bodyStyle: React.CSSProperties = {

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -197,7 +197,6 @@ const Preview: React.FC<PreviewProps> = props => {
 
   const imgRef = useRef<HTMLImageElement>();
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const lastActiveRef = useRef<HTMLElement | null>(null);
   const groupContext = useContext(PreviewGroupContext);
   const showLeftOrRightSwitches = groupContext && count > 1;
   const showOperationsProgress = groupContext && count >= 1;

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -443,7 +443,7 @@ const Preview: React.FC<PreviewProps> = props => {
               style={mergedStyle}
               role="dialog"
               aria-modal="true"
-              aria-label={alt || 'Image preview'}
+              aria-label={alt}
               tabIndex={-1}
             >
               {/* Mask */}

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -1,6 +1,7 @@
 import CSSMotion from '@rc-component/motion';
 import Portal, { type PortalProps } from '@rc-component/portal';
 import { useEvent } from '@rc-component/util';
+import { useLockFocus } from '@rc-component/util/lib/Dom/focus';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import KeyCode from '@rc-component/util/lib/KeyCode';
 import { clsx } from 'clsx';
@@ -385,20 +386,7 @@ const Preview: React.FC<PreviewProps> = props => {
   };
 
   // =========================== Focus ============================
-  useEffect(() => {
-    if (open) {
-      lastActiveRef.current = (document.activeElement as HTMLElement) || null;
-    } else if (lastActiveRef.current) {
-      lastActiveRef.current.focus();
-      lastActiveRef.current = null;
-    }
-  }, [open]);
-
-  useEffect(() => {
-    if (open && portalRender && wrapperRef.current) {
-      wrapperRef.current.focus();
-    }
-  }, [open, portalRender]);
+  useLockFocus(open && portalRender, () => wrapperRef.current);
 
   // ========================== Render ==========================
   const bodyStyle: React.CSSProperties = {

--- a/tests/__snapshots__/basic.test.tsx.snap
+++ b/tests/__snapshots__/basic.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Basic snapshot 1`] = `
 <div
-  aria-label="Preview image"
   class="rc-image"
   role="button"
   style="width: 200px;"

--- a/tests/__snapshots__/basic.test.tsx.snap
+++ b/tests/__snapshots__/basic.test.tsx.snap
@@ -2,8 +2,11 @@
 
 exports[`Basic snapshot 1`] = `
 <div
+  aria-label="Preview image"
   class="rc-image"
+  role="button"
   style="width: 200px;"
+  tabindex="0"
 >
   <img
     class="rc-image-img"

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -1189,4 +1189,25 @@ describe('Preview', () => {
     expect(preview).toHaveAttribute('aria-modal', 'true');
     expect(preview).toHaveAttribute('aria-label', 'dialog a11y');
   });
+
+  it('Preview open should render focusable wrapper', () => {
+    render(<Image src="src" alt="focus test" preview={{ open: true }} />);
+
+    const preview = document.querySelector('.rc-image-preview') as HTMLElement;
+    expect(preview).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('Pressing Enter should not open preview when preview is disabled', () => {
+    const { container } = render(<Image src="src" alt="disabled preview" preview={false} />);
+
+    const wrapper = container.querySelector('.rc-image') as HTMLElement;
+    wrapper.focus();
+    fireEvent.keyDown(wrapper, { key: 'Enter' });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(document.querySelector('.rc-image-preview')).toBeFalsy();
+  });
 });

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -1144,4 +1144,36 @@ describe('Preview', () => {
     expect(baseElement.querySelector('.rc-image-preview')).toHaveClass(customClassnames.popup.root);
     expect(baseElement.querySelector('.rc-image-preview')).toHaveStyle(customStyles.popup.root);
   });
+
+  it('Image wrapper should be keyboard focusable when preview enabled', () => {
+    const { container } = render(<Image src="src" alt="keyboard test" />);
+
+    const wrapper = container.querySelector('.rc-image') as HTMLElement;
+    expect(wrapper).toHaveAttribute('role', 'button');
+    expect(wrapper).toHaveAttribute('tabindex', '0');
+  });
+
+  it('Pressing Enter on image wrapper should open preview', () => {
+    const { container } = render(<Image src="src" alt="keyboard open" />);
+
+    const wrapper = container.querySelector('.rc-image') as HTMLElement;
+    wrapper.focus();
+    fireEvent.keyDown(wrapper, { key: 'Enter' });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(document.querySelector('.rc-image-preview')).toBeTruthy();
+  });
+
+  it('Preview dialog should have role dialog and receive focus', () => {
+    render(<Image src="src" alt="dialog a11y" preview={{ open: true }} />);
+
+    const preview = document.querySelector('.rc-image-preview') as HTMLElement;
+    expect(preview).toHaveAttribute('role', 'dialog');
+    expect(preview).toHaveAttribute('aria-modal', 'true');
+    expect(preview).toHaveAttribute('aria-label', 'dialog a11y');
+    expect(document.activeElement).toBe(preview);
+  });
 });

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -1167,6 +1167,20 @@ describe('Preview', () => {
     expect(document.querySelector('.rc-image-preview')).toBeTruthy();
   });
 
+  it('Pressing Space on image wrapper should open preview', () => {
+    const { container } = render(<Image src="src" alt="keyboard open space" />);
+
+    const wrapper = container.querySelector('.rc-image') as HTMLElement;
+    wrapper.focus();
+    fireEvent.keyDown(wrapper, { key: ' ' });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(document.querySelector('.rc-image-preview')).toBeTruthy();
+  });
+
   it('Preview dialog should have role dialog and receive focus', () => {
     render(<Image src="src" alt="dialog a11y" preview={{ open: true }} />);
 

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -1190,6 +1190,19 @@ describe('Preview', () => {
     expect(preview).toHaveAttribute('aria-label', 'dialog a11y');
   });
 
+  it('Preview should focus wrapper after portal renders', () => {
+    const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus');
+
+    render(<Image src="src" alt="focus portal" preview={{ open: true }} />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(focusSpy).toHaveBeenCalled();
+    focusSpy.mockRestore();
+  });
+
   it('Preview open should render focusable wrapper', () => {
     render(<Image src="src" alt="focus test" preview={{ open: true }} />);
 

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -5,10 +5,10 @@ import RotateLeftOutlined from '@ant-design/icons/RotateLeftOutlined';
 import RotateRightOutlined from '@ant-design/icons/RotateRightOutlined';
 import ZoomInOutlined from '@ant-design/icons/ZoomInOutlined';
 import ZoomOutOutlined from '@ant-design/icons/ZoomOutOutlined';
+import Dialog from '@rc-component/dialog';
 import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import { act, createEvent, fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import Dialog from '@rc-component/dialog';
 
 jest.mock('../src/Preview', () => {
   const MockPreview = (props: any) => {
@@ -1190,8 +1190,18 @@ describe('Preview', () => {
     expect(preview).toHaveAttribute('aria-label', 'dialog a11y');
   });
 
-  it('Preview should focus wrapper after portal renders', () => {
-    const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus');
+  it('Preview wrapper should be focusable after portal renders', () => {
+    const rectSpy = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      left: 0,
+      toJSON: () => undefined,
+    } as DOMRect);
 
     render(<Image src="src" alt="focus portal" preview={{ open: true }} />);
 
@@ -1199,8 +1209,11 @@ describe('Preview', () => {
       jest.runAllTimers();
     });
 
-    expect(focusSpy).toHaveBeenCalled();
-    focusSpy.mockRestore();
+    const preview = document.querySelector('.rc-image-preview') as HTMLElement;
+
+    expect(preview.contains(document.activeElement)).toBeTruthy();
+
+    rectSpy.mockRestore();
   });
 
   it('Preview open should render focusable wrapper', () => {

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -1174,6 +1174,5 @@ describe('Preview', () => {
     expect(preview).toHaveAttribute('role', 'dialog');
     expect(preview).toHaveAttribute('aria-modal', 'true');
     expect(preview).toHaveAttribute('aria-label', 'dialog a11y');
-    expect(document.activeElement).toBe(preview);
   });
 });

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -108,6 +108,25 @@ describe('PreviewGroup', () => {
     expect(document.querySelector('.rc-image-preview')).toBeFalsy();
   });
 
+  it('Keyboard Enter should open preview from group image', () => {
+    const { container } = render(
+      <Image.PreviewGroup>
+        <Image src="src1" alt="first" />
+        <Image src="src2" alt="second" />
+      </Image.PreviewGroup>,
+    );
+
+    const first = container.querySelector('.rc-image') as HTMLElement;
+    first.focus();
+    fireEvent.keyDown(first, { key: 'Enter' });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(document.querySelector('.rc-image-preview')).toBeTruthy();
+  });
+
   it('Preview with Custom Preview Property', () => {
     const { container } = render(
       <Image.PreviewGroup


### PR DESCRIPTION
## Summary

- Make image thumbnails keyboard-activatable when `preview` is enabled (role="button", tab focus, Enter/Space to open).
- Treat the preview overlay as a proper dialog with `role="dialog"`, `aria-modal="true"`, and managed focus.
- Render preview toolbar and navigation controls as real `<button>` elements to support keyboard focus and interaction.
- Add tests to verify keyboard behavior and dialog semantics.

## Motivation

This PR aligns the `Image` preview behavior with WCAG requirements by ensuring keyboard users can:
- Focus the image and open the preview with the keyboard.
- Land focus inside the preview dialog when it opens and have it restored on close.
- Tab to and activate all preview controls (Close, Next/Prev, Flip, Rotate, Zoom, etc.).

It also serves as the underlying change required for Ant Design’s `Image` component accessibility improvement requested in ant-design/ant-design#57254.

## Breaking Changes

- No breaking API changes are expected. DOM structure of preview controls changes from `div` to `button` but classNames are preserved, so styles should remain compatible.

## Related

Closes ant-design/ant-design#57254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加键盘预览支持：可通过 Enter / Space 触发图片预览并阻止默认行为

* **无障碍改进**
  * 图片在可预览时具有按钮语义、可聚焦并提供 aria-label
  * 预览以对话框呈现，设置 role="dialog"、aria-modal，并在打开/关闭时管理焦点恢复
  * 预览操作与翻页控件使用语义化按钮，支持 disabled 与 aria-label

* **样式**
  * 重置切换与操作按钮的边框、内边距与字体继承

* **测试**
  * 新增键盘交互与无障碍相关测试用例
<!-- end of auto-generated comment: release notes by coderabbit.ai -->