### PR TITLE
feat: add `-movable` classname

### DIFF
--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -419,6 +419,7 @@ const Preview: React.FC<PreviewProps> = props => {
           return (
             <div
               className={clsx(prefixCls, rootClassName, classNames.root, motionClassName, {
+                [`${prefixCls}-movable`]: movable,
                 [`${prefixCls}-moving`]: isMoving,
               })}
               style={mergedStyle}

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -5,10 +5,10 @@ import RotateLeftOutlined from '@ant-design/icons/RotateLeftOutlined';
 import RotateRightOutlined from '@ant-design/icons/RotateRightOutlined';
 import ZoomInOutlined from '@ant-design/icons/ZoomInOutlined';
 import ZoomOutOutlined from '@ant-design/icons/ZoomOutOutlined';
+import Dialog from '@rc-component/dialog';
 import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import { act, createEvent, fireEvent, render } from '@testing-library/react';
-import React, { useState } from 'react';
-import Dialog from '@rc-component/dialog';
+import React from 'react';
 
 jest.mock('../src/Preview', () => {
   const MockPreview = (props: any) => {
@@ -376,6 +376,26 @@ describe('Preview', () => {
     expect(document.querySelector('.rc-image-preview-img')).toHaveStyle({
       transform: 'translate3d(75px, 75px, 0) scale3d(1.5, 1.5, 1) rotate(0deg)',
     });
+  });
+
+  it('should render movable className correctly according to movable prop', () => {
+    const { rerender } = render(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        preview={{ open: true }}
+      />,
+    );
+
+    expect(document.querySelector('.rc-image-preview')).toHaveClass('rc-image-preview-movable');
+
+    rerender(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        preview={{ open: true, movable: false }}
+      />,
+    );
+
+    expect(document.querySelector('.rc-image-preview')).not.toHaveClass('rc-image-preview-movable');
   });
 
   it('Mouse Event', () => {


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/57249

新增一个`-movable` 类名，在antd侧，单独写`-movable`的样式`cursor: 'grab'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 预览组件新增“可移动”样式支持：当启用时，会在预览根元素应用对应样式以实现可移动相关视觉行为。
  
* **测试**
  * 增强了预览相关测试，新增用例验证根据可移动属性动态添加或移除对应样式类，确保行为一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->