### PR TITLE
fix: lock focus inside preview when opened via keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@rc-component/motion": "^1.0.0",
     "@rc-component/portal": "^2.1.2",
-    "@rc-component/util": "^1.10.0",
+    "@rc-component/util": "^1.10.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -196,7 +196,9 @@ const Preview: React.FC<PreviewProps> = props => {
   } = props;
 
   const imgRef = useRef<HTMLImageElement>();
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement>(null);
+  const [wrapperEl, setWrapperEl] = useState<HTMLDivElement>(null);
+
   const groupContext = useContext(PreviewGroupContext);
   const showLeftOrRightSwitches = groupContext && count > 1;
   const showOperationsProgress = groupContext && count >= 1;
@@ -366,6 +368,10 @@ const Preview: React.FC<PreviewProps> = props => {
   const onVisibleChanged = (nextVisible: boolean) => {
     if (!nextVisible) {
       setLockScroll(false);
+
+      // Restore focus to the trigger element after leave animation
+      triggerRef.current?.focus?.();
+      triggerRef.current = null;
     }
     afterOpenChange?.(nextVisible);
   };
@@ -385,7 +391,13 @@ const Preview: React.FC<PreviewProps> = props => {
   };
 
   // =========================== Focus ============================
-  useLockFocus(open && portalRender, () => wrapperRef.current);
+  useEffect(() => {
+    if (open) {
+      triggerRef.current = document.activeElement as HTMLElement;
+    }
+  }, [open]);
+
+  useLockFocus(open && !!wrapperEl, () => wrapperEl);
 
   // ========================== Render ==========================
   const bodyStyle: React.CSSProperties = {
@@ -423,7 +435,7 @@ const Preview: React.FC<PreviewProps> = props => {
 
           return (
             <div
-              ref={wrapperRef}
+              ref={setWrapperEl}
               className={clsx(prefixCls, rootClassName, classNames.root, motionClassName, {
                 [`${prefixCls}-movable`]: movable,
                 [`${prefixCls}-moving`]: isMoving,

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -196,8 +196,8 @@ const Preview: React.FC<PreviewProps> = props => {
   } = props;
 
   const imgRef = useRef<HTMLImageElement>();
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLElement>(null);
-  const [wrapperEl, setWrapperEl] = useState<HTMLDivElement>(null);
 
   const groupContext = useContext(PreviewGroupContext);
   const showLeftOrRightSwitches = groupContext && count > 1;
@@ -391,13 +391,13 @@ const Preview: React.FC<PreviewProps> = props => {
   };
 
   // =========================== Focus ============================
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (open) {
       triggerRef.current = document.activeElement as HTMLElement;
     }
   }, [open]);
 
-  useLockFocus(open && !!wrapperEl, () => wrapperEl);
+  useLockFocus(open && portalRender, () => wrapperRef.current);
 
   // ========================== Render ==========================
   const bodyStyle: React.CSSProperties = {
@@ -435,7 +435,7 @@ const Preview: React.FC<PreviewProps> = props => {
 
           return (
             <div
-              ref={setWrapperEl}
+              ref={wrapperRef}
               className={clsx(prefixCls, rootClassName, classNames.root, motionClassName, {
                 [`${prefixCls}-movable`]: movable,
                 [`${prefixCls}-moving`]: isMoving,

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -1256,4 +1256,44 @@ describe('Preview', () => {
 
     expect(document.querySelector('.rc-image-preview')).toBeFalsy();
   });
+
+  it('Focus should be trapped inside preview after keyboard open and restored on close', () => {
+    const rectSpy = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0, y: 0, width: 100, height: 100,
+      top: 0, right: 100, bottom: 100, left: 0,
+      toJSON: () => undefined,
+    } as DOMRect);
+
+    const { container } = render(<Image src="src" alt="focus trap" />);
+    const wrapper = container.querySelector('.rc-image') as HTMLElement;
+
+    // Open preview via keyboard
+    wrapper.focus();
+    expect(document.activeElement).toBe(wrapper);
+
+    fireEvent.keyDown(wrapper, { key: 'Enter' });
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // Focus should be inside the preview
+    const preview = document.querySelector('.rc-image-preview') as HTMLElement;
+    expect(preview).toBeTruthy();
+    expect(preview.contains(document.activeElement)).toBeTruthy();
+
+    // Focus should not escape when trying to focus outside
+    wrapper.focus();
+    expect(preview.contains(document.activeElement)).toBeTruthy();
+
+    // Close preview via Escape
+    fireEvent.keyDown(window, { key: 'Escape' });
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // Focus should return to the trigger element
+    expect(document.activeElement).toBe(wrapper);
+
+    rectSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Screenshot

### Before

![Clipboard-20260403-192533-706](https://github.com/user-attachments/assets/a1b7c98d-e25f-4102-9bf7-eb066e85dde1)

### After

![Clipboard-20260403-192350-368](https://github.com/user-attachments/assets/27073053-2d77-40f1-beb5-576cef5ba9b0)

CSSMotion 导致的渲染时序问题，useLockfoucs 执行时 wrapper dom 还没被挂载，但是该 hooks 的 deps 是［id,lock]，导致 wrapper dom 挂载后也不会重新触发，导致 focus trap 失效。

~~改成 state callback ref，re-render 一次让 useLockFocus 触发~~ 在 util 侧解了：https://github.com/react-component/util/pull/748/changes

🤓 Generated with 我自己

## Summary
- **Fix focus not being trapped inside preview when opened via keyboard (Enter/Space).** Root cause: CSSMotion returns `null` on first render (`styleReady='NONE'` during appear phase), so the wrapper DOM element is not available when `useLockFocus` first activates. Switched `wrapperRef` from `useRef` to `useState` callback ref so the component re-renders once the wrapper mounts, allowing `useLockFocus` to correctly lock focus.
- **Restore focus to the trigger element after preview closes.** Records `document.activeElement` as the trigger when `open` becomes `true`, then calls `triggerRef.current.focus()` in `onVisibleChanged` after the leave animation completes.

## Test plan
- [x] Added test: focus is trapped inside preview after keyboard open
- [x] Added test: focus is restored to trigger element after preview close
- [ ] Manual test: open preview with Enter key, verify Tab cycles within preview
- [ ] Manual test: close preview with Escape, verify focus returns to the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了预览的焦点管理，确保在关闭预览窗口时焦点能够正确恢复到触发元素。

* **Tests**
  * 添加了测试用例以验证键盘导航和焦点锁定行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->