### PR TITLE
[codex] support preview mask closable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ export default () => (
 | --- | --- | --- | --- |
 | open | boolean | - | Whether the preview is open or not |
 | closeIcon | React.ReactNode | - | Custom close icon |
+| maskClosable | boolean | true | Whether to close preview on clicking mask |
 | src | string | - | Customize preview src |
 | movable | boolean | true | Enable drag |
 | scaleStep | number | 0.5 | The number to which the scale is increased or decreased |
@@ -114,6 +115,7 @@ export default () => (
 | movable | boolean | true | Enable drag |
 | current | number | - | Current index |
 | closeIcon | React.ReactNode | - | Custom close icon |
+| maskClosable | boolean | true | Whether to close preview on clicking mask |
 | scaleStep | number | 0.5 | The number to which the scale is increased or decreased |
 | minScale | number | 1 | Min scale |
 | maxScale | number | 50 | Max scale |

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -87,6 +87,7 @@ export interface InternalPreviewConfig {
   open?: boolean;
   getContainer?: PortalProps['getContainer'];
   zIndex?: number;
+  maskClosable?: boolean;
   afterOpenChange?: (open: boolean) => void;
 
   // Operation
@@ -174,6 +175,7 @@ const Preview: React.FC<PreviewProps> = props => {
     onClose,
     open,
     afterOpenChange,
+    maskClosable = true,
     icons = {},
     closeIcon,
     getContainer,
@@ -450,7 +452,7 @@ const Preview: React.FC<PreviewProps> = props => {
               <div
                 className={clsx(`${prefixCls}-mask`, classNames.mask)}
                 style={styles.mask}
-                onClick={onClose}
+                onClick={maskClosable ? onClose : undefined}
               />
 
               {/* Body */}

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -101,6 +101,33 @@ describe('Preview', () => {
     expect(onPreviewCloseMock).toHaveBeenCalledWith(false);
   });
 
+  it('maskClosable should control mask close behavior only', () => {
+    const onPreviewOpenChange = jest.fn();
+    const { container } = render(
+      <Image
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        preview={{
+          maskClosable: false,
+          onOpenChange: onPreviewOpenChange,
+        }}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.rc-image'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    onPreviewOpenChange.mockReset();
+
+    fireEvent.click(document.querySelector('.rc-image-preview-mask'));
+    expect(document.querySelector('.rc-image-preview')).toBeTruthy();
+    expect(onPreviewOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.click(document.querySelector('.rc-image-preview-close'));
+    expect(onPreviewOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it('Unmount', () => {
     const { container, unmount } = render(
       <Image src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png" />,


### PR DESCRIPTION
## 变更内容

- 为 preview 增加 `maskClosable` 配置，默认保持为 `true`
- 当 `maskClosable={false}` 时，点击预览遮罩不再触发关闭
- 补充对应测试与 README 文档说明

## 变更原因

当前 `rc-image` 只支持通过 `closeIcon` 控制关闭按钮展示，但遮罩点击始终会直接触发 `onClose`。
这会导致上层即使已经计算出 mask 的 closable 语义，也无法真正控制预览遮罩的关闭行为。

## 影响说明

- `maskClosable` 只影响遮罩点击关闭行为
- 右上角关闭按钮行为保持不变
- `Esc` 关闭行为保持不变
- 为 antd 上层继续透传 `mask.closable` 提供底层能力

## 验证

- `npm run tsc`
- `npm test`

Related: ant-design/ant-design#57606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加 `maskClosable` 配置选项（默认启用），用于控制点击遮罩层是否关闭预览窗口。

* **文档**
  * 更新了预览配置选项文档，说明新增 `maskClosable` 参数。

* **测试**
  * 添加测试用例验证遮罩可关闭选项的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->