### PR TITLE
feat: add focusTrap prop to preview config

### DIFF
--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -89,6 +89,10 @@ export interface InternalPreviewConfig {
   zIndex?: number;
   afterOpenChange?: (open: boolean) => void;
 
+  // Focus
+  /** Whether to trap focus within the preview when open. Default is true. */
+  focusTrap?: boolean;
+
   // Operation
   movable?: boolean;
   icons?: OperationIcons;
@@ -193,6 +197,7 @@ const Preview: React.FC<PreviewProps> = props => {
     styles = {},
     mousePosition,
     zIndex,
+    focusTrap = true,
   } = props;
 
   const imgRef = useRef<HTMLImageElement>();
@@ -397,7 +402,7 @@ const Preview: React.FC<PreviewProps> = props => {
     }
   }, [open]);
 
-  useLockFocus(open && portalRender, () => wrapperRef.current);
+  useLockFocus(focusTrap && open && portalRender, () => wrapperRef.current);
 
   // ========================== Render ==========================
   const bodyStyle: React.CSSProperties = {

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -1296,4 +1296,28 @@ describe('Preview', () => {
 
     rectSpy.mockRestore();
   });
+
+  it('Focus should not be trapped when focusTrap is false', () => {
+    const rectSpy = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0, y: 0, width: 100, height: 100,
+      top: 0, right: 100, bottom: 100, left: 0,
+      toJSON: () => undefined,
+    } as DOMRect);
+
+    const { container } = render(<Image src="src" alt="no trap" preview={{ open: true, focusTrap: false }} />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const preview = document.querySelector('.rc-image-preview') as HTMLElement;
+    expect(preview).toBeTruthy();
+
+    // Focus outside the preview should not be redirected back
+    const wrapper = container.querySelector('.rc-image') as HTMLElement;
+    wrapper.focus();
+    expect(document.activeElement).toBe(wrapper);
+
+    rectSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

Add `focusTrap` option to `InternalPreviewConfig` (default `true`). When set to `false`, the preview will not trap focus via `useLockFocus`.

### Problem

When a preview is rendered with `open: true` inline (e.g. in antd's semantic documentation demos), `useLockFocus` activates a global `focusin` listener that prevents **all** other elements on the page from receiving keyboard focus. This breaks keyboard accessibility for the entire page.

### Solution

Add a `focusTrap` prop (consistent with `rc-dialog` and `rc-drawer` naming) to allow consumers to opt out of focus trapping:

```tsx
<Image.PreviewGroup
  preview={{ open: true, focusTrap: false }}
/>
```

**rc-dialog** already guards focus lock with `isFixedPos` and `focusTrap`:
```js
useLockFocus(visible && isFixedPos && focusTrap !== false, ...)
```

**rc-drawer** uses `focusTrap` prop:
```js
const mergedFocusTrap = focusTrap ?? mask !== false;
useLockFocus(open && mergedFocusTrap, ...)
```

**rc-image** previously had no guard:
```js
useLockFocus(open && portalRender, ...)
```

### Changes

- `InternalPreviewConfig`: add `focusTrap?: boolean` (default `true`)
- `Preview` component: pass `focusTrap` condition to `useLockFocus`
- Add test case for `focusTrap: false`

## Test plan

- [x] Existing focus trap tests still pass
- [x] New test: focus is not trapped when `focusTrap` is `false`
- [x] Verified on antd docs page: keyboard navigation works after setting `focusTrap: false` on the semantic demo's always-open preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加可配置的焦点锁定选项。用户现在可以选择启用或禁用预览打开时的焦点锁定行为，默认启用。

* **测试**
  * 添加测试用例以验证禁用焦点锁定时的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->