### PR TITLE
fix: add motionDeadline to to fix the preview not be removed when the preview closed immediately after opening

### DIFF
--- a/assets/preview.less
+++ b/assets/preview.less
@@ -7,6 +7,16 @@
   inset: 0;
   z-index: 1055;
 
+  &-pass-through {
+    pointer-events: none;
+
+    *,
+    *::before,
+    *::after {
+      pointer-events: none !important;
+    }
+  }
+
   &-mask {
     position: absolute;
     background-color: rgba(0, 0, 0, 0.3);

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -428,7 +428,7 @@ const Preview: React.FC<PreviewProps> = props => {
         motionAppear
         motionEnter
         motionLeave
-        motionDeadline={500}
+        motionDeadline={1000}
         onVisibleChanged={onVisibleChanged}
       >
         {({ className: motionClassName, style: motionStyle }) => {
@@ -447,6 +447,7 @@ const Preview: React.FC<PreviewProps> = props => {
               className={clsx(prefixCls, rootClassName, classNames.root, motionClassName, {
                 [`${prefixCls}-movable`]: movable,
                 [`${prefixCls}-moving`]: isMoving,
+                [`${prefixCls}-pass-through`]: !(portalRender && open),
               })}
               style={mergedStyle}
               role="dialog"

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -428,6 +428,7 @@ const Preview: React.FC<PreviewProps> = props => {
         motionAppear
         motionEnter
         motionLeave
+        motionDeadline={500}
         onVisibleChanged={onVisibleChanged}
       >
         {({ className: motionClassName, style: motionStyle }) => {

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -428,7 +428,7 @@ const Preview: React.FC<PreviewProps> = props => {
         motionAppear
         motionEnter
         motionLeave
-        motionDeadline={500}
+        motionDeadline={1000}
         onVisibleChanged={onVisibleChanged}
       >
         {({ className: motionClassName, style: motionStyle }) => {


### PR DESCRIPTION
### 问题描述
点击image打开图片预览弹窗的同时，立即按esc关闭时，预览弹窗不可见但是dom没有移除导致页面无法点击

### 复现步骤
antd https://ant.design/components/image-cn 中可以手动复现（点击图片打开预览的同时按esc关闭预览）

（视频中第一次手速慢了失败了，第二次复现成功）

https://github.com/user-attachments/assets/c54cbbef-cb56-4d5b-8d58-e7e7d04cf6ee

rc-image 和 rc-motion 中可以代码方式复现(不稳定复现，但概率较大)
```typescript
// rc-image
import Image from '@rc-component/image';
import * as React from 'react';
import '../../assets/index.less';

export default function PreviewMotionBDemo() {
  const [open, setOpen] = React.useState(false);

  return (
    <div>
      <button
        type="button"
        onClick={() => {
          setOpen(true);
          requestAnimationFrame(() => {
            setOpen(false);
          });
        }}
      >
        Open + Close (next frame)
      </button>
      <Image
        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
        width={200}
        preview={{ open }}
      />
    </div>
  );
}

```

### 问题原因
打开预览后快速关闭时，rc-motion 中 dom 的 `transitionend` 事件有概率不会触发，导致跳过后续的处理逻辑。代码位于 [`react-component/motion/src/hooks/useDomMotionEvents.ts`](https://github.com/react-component/motion/blob/master/src/hooks/useDomMotionEvents.ts)

### 解决方案
设置 rc-motion 的 `motionDeadline` 字段，同时在 bug 产生到 Deadline 兜底的这段时间，添加点击穿透的处理
