### PR TITLE
Avoid rc deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
   "dependencies": {
     "@rc-component/motion": "^1.0.0",
     "@rc-component/portal": "^2.1.2",
-    "@rc-component/util": "^1.10.1",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@ant-design/icons": "^5.0.1",
-    "@rc-component/father-plugin": "^2.0.2",
-    "@rc-component/np": "^1.0.0",
     "@rc-component/dialog": "^1.7.0",
+    "@rc-component/father-plugin": "^2.2.0",
+    "@rc-component/np": "^1.0.0",
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^15.0.6",
     "@types/jest": "^30.0.0",

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -1,4 +1,4 @@
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
+import { useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { useContext, useMemo, useState } from 'react';

--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -1,9 +1,6 @@
 import CSSMotion from '@rc-component/motion';
 import Portal, { type PortalProps } from '@rc-component/portal';
-import { useEvent } from '@rc-component/util';
-import { useLockFocus } from '@rc-component/util/lib/Dom/focus';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode, useEvent, useLayoutEffect, useLockFocus } from '@rc-component/util';
 import { clsx } from 'clsx';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { PreviewGroupContext } from '../context';

--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -1,5 +1,4 @@
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
+import { useControlledState, useEvent } from '@rc-component/util';
 import * as React from 'react';
 import { useState } from 'react';
 import type { ImgInfo } from './Image';

--- a/src/hooks/useImageTransform.ts
+++ b/src/hooks/useImageTransform.ts
@@ -1,7 +1,6 @@
-import { getClientSize } from '../util';
-import isEqual from '@rc-component/util/lib/isEqual';
-import raf from '@rc-component/util/lib/raf';
+import { isEqual, raf } from '@rc-component/util';
 import { useRef, useState } from 'react';
+import { getClientSize } from '../util';
 
 export type TransformType = {
   x: number;

--- a/src/hooks/useMouseEvent.ts
+++ b/src/hooks/useMouseEvent.ts
@@ -1,4 +1,4 @@
-import { warning } from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import getFixScaleEleTransPosition from '../getFixScaleEleTransPosition';

--- a/tests/placeholder.test.tsx
+++ b/tests/placeholder.test.tsx
@@ -1,5 +1,5 @@
+import { spyElementPrototypes } from '@rc-component/util';
 import { act, fireEvent, render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import React from 'react';
 import Image from '../src';
 

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -6,7 +6,7 @@ import RotateRightOutlined from '@ant-design/icons/RotateRightOutlined';
 import ZoomInOutlined from '@ant-design/icons/ZoomInOutlined';
 import ZoomOutOutlined from '@ant-design/icons/ZoomOutOutlined';
 import Dialog from '@rc-component/dialog';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import { act, createEvent, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
@@ -23,9 +23,13 @@ jest.mock('../src/Preview', () => {
   return MockPreview;
 });
 
-jest.mock('@rc-component/util/lib/hooks/useId', () => {
+jest.mock('@rc-component/util', () => {
+  const util = jest.requireActual('@rc-component/util');
   const origin = jest.requireActual('react');
-  return origin.useId;
+  return {
+    ...util,
+    useId: origin.useId,
+  };
 });
 
 import Image from '../src';
@@ -1286,8 +1290,14 @@ describe('Preview', () => {
 
   it('Focus should be trapped inside preview after keyboard open and restored on close', () => {
     const rectSpy = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      x: 0, y: 0, width: 100, height: 100,
-      top: 0, right: 100, bottom: 100, left: 0,
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      left: 0,
       toJSON: () => undefined,
     } as DOMRect);
 
@@ -1326,12 +1336,20 @@ describe('Preview', () => {
 
   it('Focus should not be trapped when focusTrap is false', () => {
     const rectSpy = jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      x: 0, y: 0, width: 100, height: 100,
-      top: 0, right: 100, bottom: 100, left: 0,
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      left: 0,
       toJSON: () => undefined,
     } as DOMRect);
 
-    const { container } = render(<Image src="src" alt="no trap" preview={{ open: true, focusTrap: false }} />);
+    const { container } = render(
+      <Image src="src" alt="no trap" preview={{ open: true, focusTrap: false }} />,
+    );
 
     act(() => {
       jest.runAllTimers();

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -23,14 +23,9 @@ jest.mock('../src/Preview', () => {
   return MockPreview;
 });
 
-jest.mock('@rc-component/util', () => {
-  const util = jest.requireActual('@rc-component/util');
+jest.mock('@rc-component/util/lib/hooks/useId', () => {
   const origin = jest.requireActual('react');
-  return {
-    __esModule: true,
-    ...util,
-    useId: origin.useId,
-  };
+  return origin.useId;
 });
 
 import Image from '../src';

--- a/tests/preview.test.tsx
+++ b/tests/preview.test.tsx
@@ -27,6 +27,7 @@ jest.mock('@rc-component/util', () => {
   const util = jest.requireActual('@rc-component/util');
   const origin = jest.requireActual('react');
   return {
+    __esModule: true,
     ...util,
     useId: origin.useId,
   };

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -1,4 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import Image from '../src';

--- a/tests/previewTouch.test.tsx
+++ b/tests/previewTouch.test.tsx
@@ -1,5 +1,5 @@
+import { spyElementPrototypes } from '@rc-component/util';
 import { act, fireEvent, render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
 import React from 'react';
 import Image from '../src';
 


### PR DESCRIPTION
## 调整内容

- 将项目内对 `@rc-component/util/lib/*` 的引用调整为从 `@rc-component/util` 根入口导入。
- 升级 `@rc-component/util` 到 `^1.11.1`，升级 `@rc-component/father-plugin` 到 `^2.2.0`。
- 测试中不再引用 `@rc-component/util/lib/test/domHook` 和 `@rc-component/util/lib/hooks/useId`，改为根入口 mock 并仅覆盖 `useId`。

## 背景

为了避免 rc 包之间依赖 `es` / `lib` 构建产物内部路径，统一改为依赖公开根入口，后续 lint 规则由 `@rc-component/father-plugin` 统一处理。

## 验证

- `npm test -- preview.test.tsx --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级运行时与开发依赖到新版本，提升兼容性与稳定性。
  * 统一并简化内部依赖导入入口，改善代码一致性。

* **Tests**
  * 更新若干测试的导入与 mock 表现以适配依赖入口变更，测试断言与逻辑保持不变。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/image/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->