### PR TITLE
fix: prevent parent scroll on keyboard navigation in preview

### DIFF
--- a/src/Preview/index.tsx
+++ b/src/Preview/index.tsx
@@ -348,8 +348,10 @@ const Preview: React.FC<PreviewProps> = props => {
       if (showLeftOrRightSwitches) {
         if (keyCode === KeyCode.LEFT) {
           onActive(-1);
+          event.preventDefault();
         } else if (keyCode === KeyCode.RIGHT) {
           onActive(1);
+          event.preventDefault();
         }
       }
     }


### PR DESCRIPTION
## Description

When the Image preview is open and the user presses LEFT/RIGHT arrow keys to switch images, the browser's default scroll behavior was not prevented. This caused the parent element to scroll instead of the Image preview navigating between images.

## Root Cause

The `onKeyDown` handler in `Preview/index.tsx` handles LEFT/RIGHT arrow keys to navigate between images, but does not call `event.preventDefault()`. The browser's default behavior for arrow keys is to scroll the scrollable parent element.

## Fix

Added `event.preventDefault()` when handling LEFT and RIGHT key events in the Preview component, preventing the browser's default scroll behavior.

## Related Issue

Closes ant-design/ant-design#56290 — Image 键盘切换图片，外部元素会跟着滚动

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化预览中的左右方向键操作，避免触发浏览器默认行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->