### PR TITLE
fix: remove obsolete ESLint 10 --ext option

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "coverage": "rc-test --coverage",
     "docs:build": "dumi build",
     "docs:deploy": "gh-pages -d docs-dist",
-    "lint": "eslint src/ --ext .ts,.tsx,.jsx,.js,.md",
+    "lint": "eslint src/",
     "prepublishOnly": "npm run compile && rc-np",
     "prettier": "prettier --write --ignore-unknown .",
     "start": "dumi dev",


### PR DESCRIPTION
## What changed

Remove the obsolete ESLint 10 `--ext` option from the repository lint script.

## Why

This repository uses ESLint 10 flat config, where `--ext` is no longer accepted. The flat config already defines TypeScript/React handling and ignores, so linting `src/` preserves the same owned source scope.

## Validation

- repository lint passed with the existing warnings and zero errors
- TypeScript 6 typecheck passed
- 8/8 suites and 80/80 existing tests passed
- Father ESM/CJS/declaration build and Less compile passed
- package output contained the expected 82 files

Development-script only; no runtime API changes.
