### PR TITLE
fix: preserve PreviewGroup imageRender contract

### DIFF
--- a/src/PreviewGroup.tsx
+++ b/src/PreviewGroup.tsx
@@ -9,7 +9,7 @@ import type { TransformType } from './hooks/useImageTransform';
 import usePreviewItems from './hooks/usePreviewItems';
 import type { ImageElementProps, OnGroupPreview } from './interface';
 
-export interface GroupPreviewConfig extends InternalPreviewConfig {
+export interface GroupPreviewConfig extends Omit<InternalPreviewConfig, 'imageRender'> {
   current?: number;
   // Similar to InternalPreviewConfig but has additional current
   imageRender?: (

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -151,6 +151,35 @@ describe('PreviewGroup', () => {
     expect(previewProgressElement.textContent).toEqual('current:1 / total:3');
   });
 
+  it('imageRender receives the current group index', () => {
+    const imageRender = jest.fn((originalNode, { current }) => (
+      <div data-testid="group-image-render" data-current={current}>
+        {originalNode}
+      </div>
+    ));
+
+    render(
+      <Image.PreviewGroup
+        items={['src1', 'src2']}
+        preview={{ open: true, imageRender }}
+      />,
+    );
+
+    expect(document.querySelector('[data-testid="group-image-render"]')).toHaveAttribute(
+      'data-current',
+      '0',
+    );
+    fireEvent.click(document.querySelector('.rc-image-preview-switch-next'));
+    expect(document.querySelector('[data-testid="group-image-render"]')).toHaveAttribute(
+      'data-current',
+      '1',
+    );
+    expect(imageRender).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ current: 1 }),
+    );
+  });
+
   it('Switch', () => {
     const previewProgressElementPath = '.rc-image-preview-progress';
     const { container } = render(


### PR DESCRIPTION
## What changed

Make `GroupPreviewConfig` omit the base `imageRender` member before redeclaring the grouped callback, and add a runtime regression test for its numeric `current` value.

## Root cause

`GroupPreviewConfig` extends `InternalPreviewConfig`, but narrows `imageRender` from an optional `info.current` to a required one. Strict TypeScript consumers therefore report TS2430 for the published declaration.

The runtime contracts are genuinely different: single-image rendering may omit `current`, while PreviewGroup always supplies its active numeric index.

## Why this shape

`Omit<InternalPreviewConfig, 'imageRender'>` preserves all other base members and allows the grouped callback to retain its stronger contract without invalid interface inheritance. Runtime JavaScript is unchanged.

## Validation

- TypeScript 5.9.3 strict consumer with `skipLibCheck: false` passed
- upstream TypeScript 6 typecheck passed
- focused PreviewGroup suite: 17/17 passed
- complete upstream suite: 8/8 suites, 81/81 tests and 1 snapshot passed
- lint, Father ESM/CJS/declaration build, Less compile, and package output passed with the separately validated ESLint 10 command compatibility adjustment

The added test verifies `imageRender` receives `current` 0 initially and 1 after navigation.
