### PR TITLE
fix: prevent preview controls from submitting forms

### DIFF
--- a/src/Preview/CloseBtn.tsx
+++ b/src/Preview/CloseBtn.tsx
@@ -14,6 +14,7 @@ export default function CloseBtn(props: CloseBtnProps) {
 
   return (
     <button
+      type="button"
       className={clsx(`${prefixCls}-close`, className)}
       style={style}
       onClick={onClick}

--- a/src/Preview/PrevNext.tsx
+++ b/src/Preview/PrevNext.tsx
@@ -27,6 +27,7 @@ export default function PrevNext(props: PrevNextProps) {
   return (
     <>
       <button
+        type="button"
         className={clsx(switchCls, `${switchCls}-prev`, {
           [`${switchCls}-disabled`]: prevDisabled,
         })}

--- a/tests/previewGroup.test.tsx
+++ b/tests/previewGroup.test.tsx
@@ -151,6 +151,28 @@ describe('PreviewGroup', () => {
     expect(previewProgressElement.textContent).toEqual('current:1 / total:3');
   });
 
+  it('uses non-submitting button types for preview controls', () => {
+    const { container } = render(
+      <Image.PreviewGroup>
+        <Image src="src1" />
+        <Image src="src2" />
+      </Image.PreviewGroup>,
+    );
+
+    fireEvent.click(container.querySelector('.rc-image'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    [
+      '.rc-image-preview-close',
+      '.rc-image-preview-switch-prev',
+      '.rc-image-preview-switch-next',
+    ].forEach(selector => {
+      expect(document.querySelector(selector)).toHaveAttribute('type', 'button');
+    });
+  });
+
   it('Switch', () => {
     const previewProgressElementPath = '.rc-image-preview-progress';
     const { container } = render(


### PR DESCRIPTION
## Summary

- mark the preview close and previous-image controls as `type="button"`
- keep them consistent with the existing next-image and action controls
- add a regression test covering all three preview navigation/close buttons

## Why

A native `<button>` defaults to `type="submit"`. When a preview portal is mounted into a form through `getContainer` (or another inline/custom container), clicking Close or Previous can therefore submit the surrounding form. These controls only operate the preview and should never submit form data.

## Verification

- regression before fix: focused suite had 16 passed / 1 failed because Close and Previous had no `type`
- focused suite after fix: 17/17 passed
- full suite: 8/8 suites, 81/81 tests, 1/1 snapshot passed
- TypeScript: passed
- ESLint: 0 errors (12 existing warnings outside this change)
- Prettier check and `git diff --check`: passed

AI assistance disclosure: Codex assisted with repository screening, duplicate/changed-file checks, test execution, and drafting. I verified the behavior, patch, and results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 预览窗口中的关闭、上一张和下一张按钮现明确标记为普通按钮，避免在表单中意外触发表单提交。
* **Tests**
  * 新增预览控件行为验证，确保相关按钮具备正确的按钮类型属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->