### PR TITLE
refactor: use renderable guard for placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@rc-component/motion": "^1.0.0",
     "@rc-component/portal": "^2.1.2",
-    "@rc-component/util": "^1.11.1",
+    "@rc-component/util": "^1.13.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -1,4 +1,4 @@
-import { useControlledState } from '@rc-component/util';
+import { isReactRenderable, useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { useContext, useMemo, useState } from 'react';
@@ -152,7 +152,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
   };
 
   // ========================= ImageProps =========================
-  const isCustomPlaceholder = placeholder && placeholder !== true;
+  const isCustomPlaceholder = isReactRenderable(placeholder) && placeholder !== true;
 
   const src = previewSrc ?? imgSrc;
   const [getImgRef, srcAndOnload, status] = useStatus({
@@ -273,7 +273,7 @@ const ImageInternal: CompoundedComponent<ImageProps> = props => {
           onError={onError}
         />
 
-        {status === 'loading' && (
+        {status === 'loading' && isCustomPlaceholder && (
           <div aria-hidden="true" className={`${prefixCls}-placeholder`}>
             {placeholder}
           </div>


### PR DESCRIPTION
## 说明

- 使用 `isReactRenderable` 统一判断自定义 placeholder
- 保留 `placeholder={true}` 的默认占位语义，并支持数字 `0`、`NaN` 等有效 React 内容
- 仅在当前 placeholder 仍可渲染时展示 loading 遮罩，避免动态移除后残留空遮罩
- 将 `@rc-component/util` 的最低版本提升到首次提供该 helper 的 `^1.13.0`

## 验证

- `npm run tsc`
- `npm test -- --runInBand`
- `npx prettier --check src/Image.tsx`
- `git diff --check`

关联 ant-design/ant-design#59193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化图片加载占位符的显示逻辑。
  - 仅当占位符为可渲染的 React 内容时，才会在图片加载期间显示；不会再因传入任意真值而错误显示占位符。
  - 改善了图片加载状态下的展示效果与兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->